### PR TITLE
Add support for cherry stabilizers

### DIFF
--- a/src/functions.scad
+++ b/src/functions.scad
@@ -5,6 +5,9 @@
 // cherry stem dimensions
 function outer_cherry_stem(slop) = [7.2 - slop * 2, 5.5 - slop * 2];
 
+// cherry stabilizer stem dimensions
+function outer_cherry_stabilizer_stem(slop) = [4.85 - slop * 2, 6.05 - slop * 2];
+
 // box (kailh) switches have a bit less to work with
 function outer_box_cherry_stem(slop) = [6 - slop, 6 - slop];
 

--- a/src/key.scad
+++ b/src/key.scad
@@ -286,7 +286,7 @@ module key(inset = false) {
   }
 
   // both stem and support are optional
-  if ($stem_type != "disable" || $stabilizer_type != "disable") {
+  if ($stem_type != "disable" || ($stabilizers != [] && $stabilizer_type != "disable")) {
     dished($keytop_thickness, $inverted_dish) {
       translate([0, 0, $stem_inset]) {
         if ($stabilizer_type != "disable") stems_for($stabilizers, $stabilizer_type);

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -34,9 +34,10 @@ module rotated() {
   children();
 }
 
-module stabilized(mm=12, vertical = false, type="cherry") {
+module stabilized(mm=12, vertical = false, type=undef) {
   if (vertical) {
-    $stabilizer_type = type;
+    $stabilizer_type = type ? type : $stabilizer_type ? $stabilizer_type : "costar_stabilizer";
+    echo($stabilizer_type);
     $stabilizers = [
     [0,  mm],
     [0, -mm]
@@ -44,7 +45,10 @@ module stabilized(mm=12, vertical = false, type="cherry") {
 
     children();
   } else {
-    $stabilizer_type = type;
+    echo($stabilizer_type);
+    $stabilizer_type = type ? type : $stabilizer_type ? $stabilizer_type : "costar_stabilizer";
+    echo($stabilizer_type);
+
     $stabilizers = [
       [mm,  0],
       [-mm, 0]

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -37,7 +37,6 @@ module rotated() {
 module stabilized(mm=12, vertical = false, type=undef) {
   if (vertical) {
     $stabilizer_type = type ? type : $stabilizer_type ? $stabilizer_type : "costar_stabilizer";
-    echo($stabilizer_type);
     $stabilizers = [
     [0,  mm],
     [0, -mm]
@@ -45,9 +44,7 @@ module stabilized(mm=12, vertical = false, type=undef) {
 
     children();
   } else {
-    echo($stabilizer_type);
     $stabilizer_type = type ? type : $stabilizer_type ? $stabilizer_type : "costar_stabilizer";
-    echo($stabilizer_type);
 
     $stabilizers = [
       [mm,  0],

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -92,7 +92,7 @@ $dish_overdraw_height = 0;
 $cherry_bevel = true;
 
 // How tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
-$stem_support_height = 0.4;
+$stem_support_height = .8;
 // Font used for text
 $font="DejaVu Sans Mono:style=Book";
 // Whether or not to render fake keyswitches to check clearances
@@ -125,8 +125,8 @@ $legends = [];
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
-// Enable stabilizers. If you don't want stabilizers use disable; most other keycaps use Cherry stabilizers
-$stabilizer_type = "cherry"; // [cherry, rounded_cherry, alps, disable]
+// Enable stabilizers. Stabilizers use their own special
+$stabilizer_type = "costar_stabilizer"; // [costar_stabilizer, cherry_stabilizer, disable]
 
 // Ternaries are ONLY for customizer. they will NOT work if you're using this in
 // OpenSCAD. you should use stabilized(), openSCAD customizer,

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -125,7 +125,7 @@ $legends = [];
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
-// Enable stabilizers. Stabilizers use their own special
+// Enable stabilizer stems, to hold onto your cherry or costar stabilizers
 $stabilizer_type = "costar_stabilizer"; // [costar_stabilizer, cherry_stabilizer, disable]
 
 // Ternaries are ONLY for customizer. they will NOT work if you're using this in

--- a/src/stem_supports/brim.scad
+++ b/src/stem_supports/brim.scad
@@ -41,7 +41,7 @@ module brim_support(stem_type, stem_support_height, slop) {
         }
       }
 
-      rotate(90) inside_cherry_cross(slop);
+      inside_cherry_cross(slop);
     }
   }
 }

--- a/src/stem_supports/brim.scad
+++ b/src/stem_supports/brim.scad
@@ -8,7 +8,7 @@ module brim_support(stem_type, stem_support_height, slop) {
         square($alps_stem + [2,2], center=true);
       }
     }
-  } else if (stem_type == "cherry") {
+  } else if (stem_type == "cherry" || stem_type == "costar_stabilizer") {
     difference() {
       linear_extrude(height = stem_support_height){
         offset(r=1){
@@ -32,6 +32,16 @@ module brim_support(stem_type, stem_support_height, slop) {
       }
 
       inside_cherry_cross(slop);
+    }
+  } else if (stem_type == "cherry_stabilizer") {
+    difference() {
+      linear_extrude(height = stem_support_height){
+        offset(r=1){
+          square(outer_cherry_stabilizer_stem(slop) + [2,2], center=true);
+        }
+      }
+
+      rotate(90) inside_cherry_cross(slop);
     }
   }
 }

--- a/src/stem_supports/tines.scad
+++ b/src/stem_supports/tines.scad
@@ -7,15 +7,25 @@ module centered_tines(stem_support_height) {
 }
 
 module tines_support(stem_type, stem_support_height, slop) {
-  if (stem_type == "cherry") {
+  if (stem_type == "cherry" || stem_type == "costar_stabilizer") {
     difference () {
       union() {
         if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness), 1, $stem_support_height], center = true);
-        translate([2,0,$stem_support_height / 2]) cube([1, total_key_height($wall_thickness), $stem_support_height], center = true);
-        translate([-2,0,$stem_support_height / 2]) cube([1, total_key_height($wall_thickness), $stem_support_height], center = true);
+        translate([1.15,0,$stem_support_height / 2]) cube([.5, total_key_height($wall_thickness), $stem_support_height], center = true);
+        translate([-1.15,0,$stem_support_height / 2]) cube([.5, total_key_height($wall_thickness), $stem_support_height], center = true);
       }
 
       inside_cherry_cross(slop);
+    }
+  } else if (stem_type == "cherry_stabilizer") {
+    difference () {
+      union() {
+        //if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness), 1, $stem_support_height], center = true);
+        translate([1.15,0,$stem_support_height / 2]) cube([1, total_key_height($wall_thickness), $stem_support_height], center = true);
+        translate([-1.15,0,$stem_support_height / 2]) cube([1, total_key_height($wall_thickness), $stem_support_height], center = true);
+      }
+
+      rotate(90) inside_cherry_cross(slop);
     }
   } else if (stem_type == "box_cherry") {
     difference () {

--- a/src/stem_supports/tines.scad
+++ b/src/stem_supports/tines.scad
@@ -25,7 +25,7 @@ module tines_support(stem_type, stem_support_height, slop) {
         translate([-1.15,0,$stem_support_height / 2]) cube([1, total_key_height($wall_thickness), $stem_support_height], center = true);
       }
 
-      rotate(90) inside_cherry_cross(slop);
+      inside_cherry_stabilizer_cross(slop);
     }
   } else if (stem_type == "box_cherry") {
     difference () {

--- a/src/stems.scad
+++ b/src/stems.scad
@@ -3,13 +3,14 @@ include <stems/rounded_cherry.scad>
 include <stems/box_cherry.scad>
 include <stems/alps.scad>
 include <stems/filled.scad>
+include <stems/stabilizer.scad>
 
 
 //whole stem, alps or cherry, trimmed to fit
 module stem(stem_type, depth, slop){
     if (stem_type == "alps") {
       alps_stem(depth, slop);
-    } else if (stem_type == "cherry") {
+    } else if (stem_type == "cherry" || stem_type == "costar_stabilizer") {
       cherry_stem(depth, slop);
     } else if (stem_type == "rounded_cherry") {
       rounded_cherry_stem(depth, slop);
@@ -17,9 +18,12 @@ module stem(stem_type, depth, slop){
       box_cherry_stem(depth, slop);
     } else if (stem_type == "filled") {
       filled_stem();
+    } else if (stem_type == "cherry_stabilizer") {
+      cherry_stabilizer_stem(depth, slop);
     } else if (stem_type == "disable") {
       children();
     } else {
-      echo("Warning: unsupported $stem_type");
+      echo("Warning: unsupported $stem_type: ");
+      echo(stem_type);
     }
 }

--- a/src/stems.scad
+++ b/src/stems.scad
@@ -3,7 +3,7 @@ include <stems/rounded_cherry.scad>
 include <stems/box_cherry.scad>
 include <stems/alps.scad>
 include <stems/filled.scad>
-include <stems/stabilizer.scad>
+include <stems/cherry_stabilizer.scad>
 
 
 //whole stem, alps or cherry, trimmed to fit

--- a/src/stems/cherry_stabilizer.scad
+++ b/src/stems/cherry_stabilizer.scad
@@ -13,11 +13,6 @@ module inside_cherry_stabilizer_cross(slop) {
       square(cherry_cross(slop, extra_vertical)[1], center=true);
     }
   }
-
-  // Guides to assist insertion and mitigate first layer squishing
-  if ($cherry_bevel){
-
-  }
 }
 
 module cherry_stabilizer_stem(depth, slop) {
@@ -29,6 +24,6 @@ module cherry_stabilizer_stem(depth, slop) {
       }
     }
 
-    rotate(90) inside_cherry_stabilizer_cross(slop);
+    inside_cherry_stabilizer_cross(slop);
   }
 }

--- a/src/stems/stabilizer.scad
+++ b/src/stems/stabilizer.scad
@@ -1,0 +1,34 @@
+include <../functions.scad>
+
+// extra length to the vertical tine of the inside cherry cross
+// splits the stem into halves - allows easier fitment
+extra_vertical = 0.6;
+
+module inside_cherry_stabilizer_cross(slop) {
+  // inside cross
+  // translation purely for aesthetic purposes, to get rid of that awful lattice
+  translate([0,0,-0.005]) {
+    linear_extrude(height = $stem_throw) {
+      square(cherry_cross(slop, extra_vertical)[0], center=true);
+      square(cherry_cross(slop, extra_vertical)[1], center=true);
+    }
+  }
+
+  // Guides to assist insertion and mitigate first layer squishing
+  if ($cherry_bevel){
+
+  }
+}
+
+module cherry_stabilizer_stem(depth, slop) {
+  difference(){
+    // outside shape
+    linear_extrude(height = depth) {
+      offset(r=1){
+        square(outer_cherry_stabilizer_stem(slop) - [2,2], center=true);
+      }
+    }
+
+    rotate(90) inside_cherry_stabilizer_cross(slop);
+  }
+}

--- a/src/supports/flared.scad
+++ b/src/supports/flared.scad
@@ -25,6 +25,13 @@ module flared(stem_type, loft, height) {
           square(outer_box_cherry_stem($stem_slop) - [2,2], center=true);
         }
       }
+    } else if (stem_type == "cherry_stabilizer") {
+      cherry_scale = [scale_for_45(height, outer_cherry_stabilizer_stem($stem_slop)[0]), scale_for_45(height, outer_cherry_stabilizer_stem($stem_slop)[1])];
+      linear_extrude(height=height, scale = cherry_scale){
+        offset(r=1){
+          square(outer_cherry_stabilizer_stem($stem_slop) - [2,2], center=true);
+        }
+      }
     } else {
       // always render cherry if no stem type. this includes stem_type = false!
       // this avoids a bug where the keycap is rendered filled when not desired


### PR DESCRIPTION
ERLindeman found that cherry stabilizers don't really work with the library. Up until this point I had just been rendering Cherry stems where the stabilizer inserts would go; works fine for costar stabilizers, so I figured I'd keep them.

$stabilizer_type is now either "costar_stabilizers", "cherry_stabilizers", or "disable"; it used to be whatever $stem_type was (and it still can be, I didn't add first party support for stabilizers, I just made the cherry stabilizers a type of stem).

I also added a few tweaks to the library that I found while I was printing, which I will go through below because I forget them