### PR TITLE
fix incorrect cherry cross

### DIFF
--- a/src/functions.scad
+++ b/src/functions.scad
@@ -16,9 +16,9 @@ function outer_box_cherry_stem(slop) = [6 - slop, 6 - slop];
 // .005 purely for aesthetics, to get rid of that ugly crosshatch
 function cherry_cross(slop, extra_vertical = 0) = [
   // horizontal tine
-  [4.03 + slop, 1.15 + slop / 3],
+  [4.03 + slop, 1.25 + slop / 3],
   // vertical tine
-  [1.25 + slop / 3, 4.23 + extra_vertical + slop / 3 + SMALLEST_POSSIBLE],
+  [1.15 + slop / 3, 4.23 + extra_vertical + slop / 3 + SMALLEST_POSSIBLE],
 ];
 
 // actual mm key width and height


### PR DESCRIPTION
fixes #7, @kibogaoka noticed the dimensions were swapped. This probably went unnoticed due to the default mx stem being designed to flex and squeeze the cruciform; it was just squeezing harder in one direction and less in the other