### PR TITLE
Add double-sculpting

### DIFF
--- a/keys.scad
+++ b/keys.scad
@@ -13,8 +13,9 @@ include <src/key_profiles.scad>
 include <src/key_types.scad>
 include <src/key_transformations.scad>
 include <src/key_helpers.scad>
+include <src/layouts.scad>
 
-sa_row(3) u(3) stabilized() {
-  /* %envelope(0); */
-  key();
+for (x = [1:1:5]) {
+  translate_u(0,-x) hipro_row(x) key();
+  translate_u(1,-x) sa_row(x) key();
 }

--- a/src/key.scad
+++ b/src/key.scad
@@ -83,11 +83,15 @@ module hull_shape_hull(thickness_difference, depth_difference, extra_slices = 0)
 
 module shape_slice(progress, thickness_difference, depth_difference) {
   skew_this_slice = $top_skew * progress;
-  depth_this_slice = ($total_depth - depth_difference) * progress;
-  tilt_this_slice = -$top_tilt / $key_height * progress;
+  x_skew_this_slice = $top_skew_x * progress;
 
-  translate([0, skew_this_slice, depth_this_slice]) {
-    rotate([tilt_this_slice,0,0]){
+  depth_this_slice = ($total_depth - depth_difference) * progress;
+
+  tilt_this_slice = -$top_tilt / $key_height * progress;
+  y_tilt_this_slice = $double_sculpted ? (-$top_tilt_y / $key_length * progress) : 0;
+
+  translate([x_skew_this_slice, skew_this_slice, depth_this_slice]) {
+    rotate([tilt_this_slice,y_tilt_this_slice,0]){
       linear_extrude(height = SMALLEST_POSSIBLE){
         key_shape(
           [
@@ -113,8 +117,12 @@ module inside() {
 
 // put something at the top of the key, with no adjustments for dishing
 module top_placement(depth_difference) {
-  translate([$dish_skew_x, $top_skew + $dish_skew_y, $total_depth - depth_difference]){
-    rotate([-$top_tilt / $key_height,0,0]){
+  top_tilt_by_height = -$top_tilt / $key_height;
+  top_tilt_y_by_length = $double_sculpted ? (-$top_tilt_y / $key_length) : 0;
+
+
+  translate([$top_skew_x + $dish_skew_x, $top_skew + $dish_skew_y, $total_depth - depth_difference]){
+    rotate([top_tilt_by_height, top_tilt_y_by_length,0]){
       children();
     }
   }

--- a/src/key_profiles.scad
+++ b/src/key_profiles.scad
@@ -7,19 +7,22 @@ include <key_profiles/oem.scad>
 include <key_profiles/dsa.scad>
 include <key_profiles/sa.scad>
 include <key_profiles/g20.scad>
+include <key_profiles/hipro.scad>
 
 // man, wouldn't it be so cool if functions were first order
-module key_profile(key_profile_type, row) {
+module key_profile(key_profile_type, row, column=0) {
   if (key_profile_type == "dcs") {
-    dcs_row(row) children();
+    dcs_row(row, column) children();
   } else if (key_profile_type == "oem") {
-    oem_row(row) children();
+    oem_row(row, column) children();
   } else if (key_profile_type == "dsa") {
-    dsa_row(row) children();
+    dsa_row(row, column) children();
   } else if (key_profile_type == "sa") {
-    sa_row(row) children();
+    sa_row(row, column) children();
   } else if (key_profile_type == "g20") {
-    g20_row(row) children();
+    g20_row(row, column) children();
+  } else if (key_profile_type == "hipro") {
+    hipro_row(row, column) children();
   } else if (key_profile_type == "disable") {
     children();
   } else {

--- a/src/key_profiles/dcs.scad
+++ b/src/key_profiles/dcs.scad
@@ -1,4 +1,4 @@
-module dcs_row(n=3) {
+module dcs_row(row=3, column=0) {
   // names, so I don't go crazy
   $bottom_key_width = 18.16;
   $bottom_key_height = 18.16;
@@ -10,23 +10,26 @@ module dcs_row(n=3) {
   $dish_skew_y = 0;
   $top_skew = 1.75;
 
-  if (n == 5) {
+  $top_tilt_y = column * 3;
+
+  // hack so you can do these in a for loop
+  if (row == 5 || row == 0) {
     $total_depth = 11.5;
     $top_tilt = -6;
     children();
-  } else if (n == 1) {
+  } else if (row == 1) {
     $total_depth = 8.5;
     $top_tilt = -1;
     children();
-  } else if (n == 2) {
+  } else if (row == 2) {
     $total_depth = 7.5;
     $top_tilt = 3;
     children();
-  } else if (n == 3) {
+  } else if (row == 3) {
     $total_depth = 6;
     $top_tilt = 7;
     children();
-  } else if (n == 4) {
+  } else if (row == 4) {
     $total_depth = 6;
     $top_tilt = 16;
     children();

--- a/src/key_profiles/dsa.scad
+++ b/src/key_profiles/dsa.scad
@@ -1,10 +1,10 @@
-module dsa_row(n=3) {
+module dsa_row(row=3, column = 0) {
   $key_shape_type = "sculpted_square";
   $bottom_key_width = 18.24; // 18.4;
   $bottom_key_height = 18.24; // 18.4;
   $width_difference = 6; // 5.7;
   $height_difference = 6; // 5.7;
-  $top_tilt = n == 5 ? -21 : (n-3) * 7;
+  $top_tilt = row == 5 ? -21 : (row-3) * 7;
   $top_skew = 0;
   $dish_type = "spherical";
   $dish_depth = 1.2;
@@ -12,25 +12,25 @@ module dsa_row(n=3) {
   $dish_skew_y = 0;
   $height_slices = 10;
   $enable_side_sculpting = true;
-  // might wanna change this if you don't minkowski
-  // do you even minkowski bro
   $corner_radius = 0.25;
 
+  $top_tilt_y = column * 3;
+
   depth_raisers = [0, 3.5, 1, 0, 1, 3];
-  if (n == 5) {
-    $total_depth = 8.1 + depth_raisers[n];
+  if (row == 5) {
+    $total_depth = 8.1 + depth_raisers[row];
     children();
-  } else if (n == 1) {
-    $total_depth = 8.1 + depth_raisers[n];
+  } else if (row == 1) {
+    $total_depth = 8.1 + depth_raisers[row];
     children();
-  } else if (n == 2) {
-    $total_depth = 8.1 + depth_raisers[n];
+  } else if (row == 2) {
+    $total_depth = 8.1 + depth_raisers[row];
     children();
-  } else if (n == 3) {
-    $total_depth = 8.1 + depth_raisers[n];
+  } else if (row == 3) {
+    $total_depth = 8.1 + depth_raisers[row];
     children();
-  } else if (n == 4) {
-    $total_depth = 8.1 + depth_raisers[n];
+  } else if (row == 4) {
+    $total_depth = 8.1 + depth_raisers[row];
     children();
   } else {
     children();

--- a/src/key_profiles/g20.scad
+++ b/src/key_profiles/g20.scad
@@ -1,4 +1,4 @@
-module g20_row(n=3) {
+module g20_row(row=3, column = 0) {
   $bottom_key_width = 18.16;
   $bottom_key_height = 18.16;
   $width_difference = 2;
@@ -16,25 +16,24 @@ module g20_row(n=3) {
   //also,
   $rounded_key = true;
 
-  if (n == 5) {
-    $total_depth = 6 + abs((n-3) * 0.5);
+  $top_tilt_y = column * 3;
+  $total_depth = 6 + abs((row-3) * 0.5);
+
+  if (row == 5 || row == 0) {
+
     $top_tilt =  -18.55;
     children();
-  } else if (n == 1) {
-    $total_depth = 6 + abs((n-3) * 0.5);
-    $top_tilt = (n-3) * 7 + 2.5;
+  } else if (row == 1) {
+    $top_tilt = (row-3) * 7 + 2.5;
     children();
-  } else if (n == 2) {
-    $total_depth = 6 + abs((n-3) * 0.5);
-    $top_tilt = (n-3) * 7 + 2.5;
+  } else if (row == 2) {
+    $top_tilt = (row-3) * 7 + 2.5;
     children();
-  } else if (n == 3) {
-    $total_depth = 6 + abs((n-3) * 0.5);
-    $top_tilt = (n-3) * 7 + 2.5;
+  } else if (row == 3) {
+    $top_tilt = (row-3) * 7 + 2.5;
     children();
-  } else if (n == 4) {
-    $total_depth = 6 + abs((n-3) * 0.5);
-    $top_tilt = (n-3) * 7 + 2.5;
+  } else if (row == 4) {
+    $top_tilt = (row-3) * 7 + 2.5;
     children();
   } else {
     children();

--- a/src/key_profiles/hipro.scad
+++ b/src/key_profiles/hipro.scad
@@ -1,0 +1,42 @@
+// my own measurements
+module hipro_row(row=3, column=0) {
+  $key_shape_type = "sculpted_square";
+
+  $bottom_key_width = 18.35;
+  $bottom_key_height = 18.17;
+
+  $width_difference = ($bottom_key_width - 12.3);
+  $height_difference = ($bottom_key_height - 12.65);
+  $dish_type = "spherical";
+  $dish_depth = 0.9;
+  $dish_skew_x = 0;
+  $dish_skew_y = 0;
+  $top_skew = 0;
+  $height_slices = 10;
+  // might wanna change this if you don't minkowski
+  // do you even minkowski bro
+  $corner_radius = 0.25;
+
+  $top_tilt_y = column * 3;
+
+  if (row == 1){
+    $total_depth = 12.7;
+    // TODO I didn't change these yet
+    $top_tilt = -13;
+    children();
+  } else if (row == 2) {
+    $total_depth = 10.1;
+    $top_tilt = -7;
+    children();
+  } else if (row == 3) {
+    $total_depth = 10.1;
+    $top_tilt = 7;
+    children();
+  } else if (row == 4 || row == 5){
+    $total_depth = 11.25;
+    $top_tilt = 13;
+    children();
+  } else {
+    children();
+  }
+}

--- a/src/key_profiles/oem.scad
+++ b/src/key_profiles/oem.scad
@@ -1,4 +1,4 @@
-module oem_row(n=3) {
+module oem_row(row=3) {
   $bottom_key_width = 18.05;
   $bottom_key_height = 18.05;
   $width_difference = 5.8;
@@ -10,23 +10,25 @@ module oem_row(n=3) {
   $top_skew = 1.75;
   $stem_inset = 1.2;
 
-  if (n == 5) {
+  $top_tilt_y = column * 3;
+
+  if (row == 5 || row == 0) {
     $total_depth = 11.2;
     $top_tilt = -3;
     children();
-  } else if (n == 1) {
+  } else if (row == 1) {
     $total_depth = 9.45;
     $top_tilt = 1;
     children();
-  } else if (n == 2) {
+  } else if (row == 2) {
     $total_depth = 9;
     $top_tilt = 6;
     children();
-  } else if (n == 3) {
+  } else if (row == 3) {
     $total_depth = 9.25;
     $top_tilt = 9;
     children();
-  } else if (n == 4) {
+  } else if (row == 4) {
     $total_depth = 9.25;
     $top_tilt = 10;
     children();

--- a/src/key_profiles/sa.scad
+++ b/src/key_profiles/sa.scad
@@ -17,7 +17,7 @@ module sa_row(n=3) {
   // making a super-sculpted top row (or bottom row!) would be real easy
   // bottom row would just be 13 tilt and 14.89 total depth
   // top row would be something new entirely - 18 tilt maybe?
-  if (n == 1 || n == 5){
+  if (n == 1){
     $total_depth = 14.89;
     $top_tilt = -13;
     children();

--- a/src/layouts.scad
+++ b/src/layouts.scad
@@ -1,0 +1,4 @@
+include <layouts/preonic/mit.scad>
+include <layouts/planck/mit.scad>
+include <layouts/lets_split/default.scad>
+include <layouts/project_zen/default.scad>

--- a/src/layouts/lets_split/default.scad
+++ b/src/layouts/lets_split/default.scad
@@ -1,0 +1,9 @@
+module lets_split_default(profile) {
+  for(x = [1:1:4]) {
+    for(y=[-2.5:0.5:3]) {
+      translate_u(y > 0 ? y * 2 + 1 : y * 2,-x) key_profile(profile, x,floor(y)) {
+        key();
+      }
+    }
+  }
+}

--- a/src/layouts/planck/mit.scad
+++ b/src/layouts/planck/mit.scad
@@ -1,0 +1,9 @@
+module planck_mit(profile) {
+  for(x = [1:1:4]) {
+    for(y=[-2.5:0.5:3]) {
+      translate_u(y * 2,-x) key_profile(profile, x,floor(y)) {
+        key();
+      }
+    }
+  }
+}

--- a/src/layouts/preonic/mit.scad
+++ b/src/layouts/preonic/mit.scad
@@ -1,0 +1,9 @@
+module preonic_mit(profile) {
+  for(x = [0:1:4]) {
+    for(y=[-2.5:0.5:3]) {
+      translate_u(y * 2,-x) key_profile(profile, x,floor(y)) {
+        key();
+      }
+    }
+  }
+}

--- a/src/layouts/project_zen/default.scad
+++ b/src/layouts/project_zen/default.scad
@@ -1,0 +1,41 @@
+/* function addl(list, c = 0) =
+  c < len(list) - 1 ?
+  list[c] + addl(list, c + 1)
+  :
+  list[c]; */
+
+function addl(list, c = 0, max=undef) =
+  max < c ? 0 :
+    (c < len(list) - 1) ? list[c] + addl(list, c + 1, max=max) :
+    list[c];
+
+function slidingSum(list, c = 1, max = undef) =
+  c < 1 || c > len(list-1) ? 0 :
+    c > max ? 0 :
+      (list[c] + list[c-1])/2 + addl(list, c + 1, max=max);
+
+module project_zen_default(profile) {
+  widths = [1.5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1.5];
+  translations = [0,1.25,2.25,3.25,4.25,5.25,6.25,7.25,8.25,9.25,10.25,11.5];
+
+  for(row = [0:1:4]) {
+    $t = 0;
+    for(column=[-2.5:0.5:3]) {
+      normalized_column = column*2 + 5;
+      $key_length = widths[normalized_column];
+
+      translate_u(translations[normalized_column],-row) key_profile(profile, row,floor(column)) {
+        key();
+      }
+    }
+  }
+
+  for (row=[0:1:1]) {
+    for (column=[0:1:1]) {
+      $key_length = 2;
+      translate_u(4.75 + row*2, -5 - column) key_profile(profile, 3,0) {
+        key();
+      }
+    }
+  }
+}

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -15,6 +15,9 @@ $font_size = 6;
 // Set this to true if you're making a spacebar!
 $inverted_dish = false;
 
+// set this to true if you are making double sculpted keycaps
+$double_sculpted = true;
+
 
 // Support type. default is "flared" for easy FDM printing; bars are more realistic, and flat could be for artisans
 $support_type = "flared"; // [flared, bars, flat, disable]
@@ -45,8 +48,15 @@ $height_difference = 4;
 $total_depth = 11.5;
 // The tilt of the dish in degrees. divided by key height
 $top_tilt = -6;
+// the y tilt of the dish in degrees. divided by key width.
+// for double axis sculpted keycaps and probably not much else
+$top_tilt_y = 0;
 // How skewed towards the back the top is (0 for center)
 $top_skew = 1.7;
+
+// how skewed towards the right the top is. unused, but implemented.
+// for double axis sculpted keycaps and probably not much else
+$top_skew_x = 0;
 
 /* Stem */
 


### PR DESCRIPTION
Whoops, or full-sculpting I guess. I saw [this post](https://www.reddit.com/r/MechanicalKeyboards/comments/e69pfw/a_fully_sculpted_keycap_set/) a little while ago and wanted to make sure I added the option to do stuff like this to my library.

You can now fully sculpt your keysets by setting the $top_tilt_y value, which defines how many degrees the top surface of the keycap will tilt. In addition I've also broken out and supported $top_skew_x, which defines how many millimeters the top of the keycap will skew horizontally. $top_tilt_y is y and $top_skew_x is x because $top_tilt_y rotates the surface around the y axis, while $top_skew_x moves the surface in the x direction. I won't be changing the names for backwards compatibility, but really $top_tilt should be $top_tilt_x and $top_skew should be $top_skew_y.

In addition, because I'm a fun guy who doesn't always separate commits on my hobby projects, I've also added a `layouts` directory with some example layouts and the hipro key profile, because I've been meaning to. I've also upgraded all the layouts to do some kind of double sculpting, though not currently like the post above. It should be very easy to implement I just haven't gotten around to it yet :p really it should be something you do per layout anyways.