### PR TITLE
Front (AKA side) legends

### DIFF
--- a/src/dishes.scad
+++ b/src/dishes.scad
@@ -4,6 +4,7 @@ include <dishes/cylindrical.scad>
 include <dishes/old_spherical.scad>
 include <dishes/sideways_cylindrical.scad>
 include <dishes/spherical.scad>
+include <dishes/flat.scad>
 
 //geodesic looks much better, but runs very slow for anything above a 2u
 geodesic=false;
@@ -21,6 +22,8 @@ module  dish(width, height, depth, inverted) {
     }
     else if ($dish_type == "old spherical") {
       old_spherical_dish(width, height, depth, inverted);
+    } else if ($dish_type == "flat") {
+      flat_dish(width, height, depth, inverted);
     } else if ($dish_type == "disable") {
       // else no dish
     } else {

--- a/src/dishes/flat.scad
+++ b/src/dishes/flat.scad
@@ -1,0 +1,3 @@
+module flat_dish(width, height, depth, inverted){
+  cube([width + 100,height + 100, depth], center=true);
+}

--- a/src/key.scad
+++ b/src/key.scad
@@ -192,6 +192,25 @@ module top_placement(depth_difference=0) {
   }
 }
 
+module front_placement() {
+  // all this math is to take top skew and tilt into account
+  // we need to find the new effective height and depth of the top, front lip
+  // of the keycap to find the angle so we can rotate things correctly into place
+  total_depth_difference = sin(-$top_tilt) * (top_total_key_height()/2);
+  total_height_difference = $top_skew + (1 - cos(-$top_tilt)) * (top_total_key_height()/2);
+
+  angle = atan2(($total_depth - total_depth_difference), ($height_difference/2 + total_height_difference));
+  hypotenuse = ($total_depth -total_depth_difference) / sin(angle);
+
+  translate([0,-total_key_height()/2,0]) {
+    rotate([-(90-angle), 0, 0]) {
+      translate([0,0,hypotenuse/2]){
+        children();
+      }
+    }
+  }
+}
+
 // just to DRY up the code
 module _dish() {
   dish(top_total_key_width() + $dish_overdraw_width, top_total_key_height() + $dish_overdraw_height, $dish_depth, $inverted_dish);
@@ -309,11 +328,21 @@ module clearance_check() {
 }
 
 module legends(depth) {
-  top_of_key() {
-    // outset legend
-    if (len($legends) > 0) {
-      for (i=[0:len($legends)-1]) {
-        keytext($legends[i][0], $legends[i][1], $legends[i][2], depth);
+  if ($front_print_legends) {
+    front_placement() {
+      if (len($legends) > 0) {
+        for (i=[0:len($legends)-1]) {
+          rotate([90,0,0]) keytext($legends[i][0], $legends[i][1], $legends[i][2], depth);
+        }
+      }
+    }
+  } else {
+    top_of_key() {
+      // outset legend
+      if (len($legends) > 0) {
+        for (i=[0:len($legends)-1]) {
+          keytext($legends[i][0], $legends[i][1], $legends[i][2], depth);
+        }
       }
     }
   }

--- a/src/key_profiles/dsa.scad
+++ b/src/key_profiles/dsa.scad
@@ -14,23 +14,24 @@ module dsa_row(row=3, column = 0) {
   $enable_side_sculpting = true;
   $corner_radius = 0.25;
 
-  $top_tilt_y = column * 3 * $double_sculpt_modifier;
+  $top_tilt_y = side_tilt(column);
+  extra_height = extra_side_tilt_height(column);
 
   depth_raisers = [0, 3.5, 1, 0, 1, 3];
-  if (row == 5) {
-    $total_depth = 8.1 + depth_raisers[row];
+  if (row < 1 || row > 4) {
+    $total_depth = 8.1 + depth_raisers[row] + extra_height;
     children();
   } else if (row == 1) {
-    $total_depth = 8.1 + depth_raisers[row];
+    $total_depth = 8.1 + depth_raisers[row] + extra_height;
     children();
   } else if (row == 2) {
-    $total_depth = 8.1 + depth_raisers[row];
+    $total_depth = 8.1 + depth_raisers[row] + extra_height;
     children();
   } else if (row == 3) {
-    $total_depth = 8.1 + depth_raisers[row];
+    $total_depth = 8.1 + depth_raisers[row] + extra_height;
     children();
   } else if (row == 4) {
-    $total_depth = 8.1 + depth_raisers[row];
+    $total_depth = 8.1 + depth_raisers[row] + extra_height;
     children();
   } else {
     children();

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -7,6 +7,11 @@ module translate_u(x=0, y=0, z=0){
   translate([x * unit, y*unit, z*unit]) children();
 }
 
+module no_stem_support() {
+  $stem_support_type = "disable";
+  children();
+}
+
 module brimmed_stem_support(height = 0.4) {
   $stem_support_type = "brim";
   $stem_support_height = height;

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -141,7 +141,8 @@ module bump(depth=undef) {
 // might not work great with fully sculpted profiles yet
 module upside_down() {
   // $top_tilt*2 because top_placement rotates by top_tilt for us
-  top_placement() rotate([180+$top_tilt*2,0,0]) {
+  // first rotate 180 to get the keycaps to face the same direction
+  rotate([0,0,180]) top_placement() rotate([180+$top_tilt*2,0,0]) {
     children();
   }
 }

--- a/src/layouts/gherkin/gherkin_bump.scad
+++ b/src/layouts/gherkin/gherkin_bump.scad
@@ -16,5 +16,7 @@ gherkin_bump_legends = [
 ];
 
 module gherkin_bump_layout(profile, row_sculpting_offset=1, column_override=undef) {
-  layout(gherkin_bump_mapping, profile, legends=gherkin_bump_legends, row_sculpting_offset=row_sculpting_offset, column_override=column_override, column_sculpt_profile="cresting_wave");
+  layout(gherkin_bump_mapping, profile, legends=gherkin_bump_legends, row_sculpting_offset=row_sculpting_offset, column_override=column_override, column_sculpt_profile="cresting_wave") {
+    children();
+  };
 }

--- a/src/layouts/layout.scad
+++ b/src/layouts/layout.scad
@@ -6,7 +6,7 @@ function abs_sum(list, x=0) =
     abs_sum([for (x = [1: len(list) - 1]) list[x]], x+abs(list[0]));
 
 function 2hands(index, total) = ((index+0.5) % (total/2)) - (total/4);
-function cresting_wave(index, total, mod=5) = (index < total/2) ? (((index + 0.5) / total)*mod) : -(mod - ((index + 0.5) / total * mod));
+function cresting_wave(index, total, mod=4) = (index < total/2) ? (((index + 0.5) / total)*mod) : -(mod - ((index + 0.5) / total * mod));
 function 1hand(index, total) = (index % (total)) - (total/2);
 
 
@@ -38,15 +38,45 @@ module layout(list, profile="dcs", legends=undef, row_sculpting_offset=0, row_ov
         translate_u(column_distance - (key_length/2), -row) {
           key_profile(profile, row_sculpting, column_value) u(key_length) legend(legends ? legends[row][column] : "") cherry() { // (row+4) % 5 + 1
             if (key_length == 6.25) {
-              spacebar() key();
+              spacebar() {
+                if ($children) {
+                  children();
+                } else {
+                  key();
+                }
+              }
             } else if (key_length == 2.25) {
-              lshift() key();
+              lshift() {
+                if ($children) {
+                  children();
+                } else {
+                  key();
+                }
+              }
             } else if (key_length == 2) {
-              backspace() key();
+              backspace() {
+                if ($children) {
+                  children();
+                } else {
+                  key();
+                }
+              }
             } else if (key_length == 2.75) {
-              rshift() key();
+              rshift() {
+                if ($children) {
+                  children();
+                } else {
+                  key();
+                }
+              }
             } else {
-              key();
+              {
+                if ($children) {
+                  children();
+                } else {
+                  key();
+                }
+              }
             }
           }
         }

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -150,6 +150,9 @@ $legends = [];
 // broken off from artisan support since who wants outset legends?
 $outset_legends = false;
 
+// print legends on the front of the key instead of the top
+$front_print_legends = false;
+
 // how recessed inset legends / artisans are from the top of the key
 $inset_legend_depth = 0.2;
 

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -151,7 +151,7 @@ $legends = [];
 $outset_legends = false;
 
 // how recessed inset legends / artisans are from the top of the key
-$inset_legend_depth = 0.3;
+$inset_legend_depth = 0.2;
 
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/510867/72214199-4a6ec400-34cb-11ea-956d-b7b567d37a6e.png)


This wasn't nearly as hard as I thought it was going to be!

You'll have to fiddle with the numbers to get things right - for instance, it looks like 0.3mm for inset legends is a little faint, and I had to go with a smaller font to fit on the g20s. However, the code is completely profile agnostic, so it should be in the correct place every time - directly in the middle of the side. could be modified to be at a certain distance (not height per se, since it's distance up the side) by changing `hypotenuse/2` here: https://github.com/rsheldiii/KeyV2/compare/front-pacement?expand=1#diff-006ddec023921f454eb3a8375b37d29eR207 but that's for another day