### PR TITLE
Add examples and sa_ergo

### DIFF
--- a/examples/sa_ergo.scad
+++ b/examples/sa_ergo.scad
@@ -1,27 +1,52 @@
 include <../includes.scad>
 
-$double_sculpted = true;
+/*
+In this example, we harness full sculpting and simple_layout to make a set of SA
+keys that look a lot like the key wells on a dactyl, dactyl manuform, or kinesis
 
+SA keys render faster with skin_extrude_shape = true, but then they don't get
+the nice flaring on the sides... yet.
+*/
+
+// to turn on full sculpting
+$double_sculpted = true;
+// to make the font fit
 $font_size = 4;
+
+// change this to make the full sculpting more or less aggressive. 200 is default
+$double_sculpt_radius = 200;
+
+// This is the exact column stagger from the dactyl transposed onto the
+// rows of the preonic default layout. the second array is for modifying the
+// values up or down - making all the 0's -1's would make each key 1mm lower
+// for instance.
 extra_column_height = [5.64, 5.64, 0, -3, 0, 0, 0, 0, 0, -3, 0, 5.64, 5.64] + [0,0,0,0,0,0,0,0,0,0,0,0,0];
+// required for double_sculpted_column
 row_length = len(preonic_default_layout[0]);
 
 simple_layout(preonic_default_layout) {
-  // uh oh, now I need two of them...
+  // this union is here because, for some reason, you cannot modify special variables
+  // that are modified in the scope directly above.
   union() {
+    // row declarations treat column 0 as perfectly center, so if we just used
+    // $column we'd have a ridiculously looking left-leaning keyboard.
+    // this function transforms the actual column value into a "2hands" column
+    // value, aka for a board with 2 "keywells", one for each hand
     column_value = double_sculpted_column($column, row_length, "2hands");
-    echo("column value", column_value);
+    /* echo("column value", column_value); */
     sa_row($row+1, column_value){
-      // this union is here because, for some reason, you cannot modify the
-      // variables dcs_row and other row decs modify in the scope below them.
+      // uh oh, now I need two of them...
       union() {
+        // uncomment when prototyping for faster prototypes!
         /* $dish_type = "disable"; */
         $stem_support_type = "disable";
+
+        // here's where the magic happens and we actually add the extra column height
         $total_depth = $total_depth + extra_column_height[$column];
-        /* key(); */
-        dished(){
-          legend(preonic_default_legends[$row][$column]) legends($inset_legend_depth);
-        }
+        key();
+
+        // this generates separate legends for the keys
+        /* legend(preonic_default_legends[$row][$column]) legends($inset_legend_depth); */
       }
     }
   }

--- a/examples/sa_ergo.scad
+++ b/examples/sa_ergo.scad
@@ -1,0 +1,28 @@
+include <../includes.scad>
+
+$double_sculpted = true;
+
+$font_size = 4;
+extra_column_height = [5.64, 5.64, 0, -3, 0, 0, 0, 0, 0, -3, 0, 5.64, 5.64] + [0,0,0,0,0,0,0,0,0,0,0,0,0];
+row_length = len(preonic_default_layout[0]);
+
+simple_layout(preonic_default_layout) {
+  // uh oh, now I need two of them...
+  union() {
+    column_value = double_sculpted_column($column, row_length, "2hands");
+    echo("column value", column_value);
+    sa_row($row+1, column_value){
+      // this union is here because, for some reason, you cannot modify the
+      // variables dcs_row and other row decs modify in the scope below them.
+      union() {
+        /* $dish_type = "disable"; */
+        $stem_support_type = "disable";
+        $total_depth = $total_depth + extra_column_height[$column];
+        /* key(); */
+        dished(){
+          legend(preonic_default_legends[$row][$column]) legends($inset_legend_depth);
+        }
+      }
+    }
+  }
+}

--- a/examples/sa_ergo.scad
+++ b/examples/sa_ergo.scad
@@ -46,7 +46,7 @@ simple_layout(preonic_default_layout) {
         key();
 
         // this generates separate legends for the keys
-        /* legend(preonic_default_legends[$row][$column]) legends($inset_legend_depth); */
+        /* legend(preonic_default_legends[$row][$column]) legends(); */
       }
     }
   }

--- a/includes.scad
+++ b/includes.scad
@@ -1,0 +1,9 @@
+use <src/key.scad>
+
+include <src/settings.scad>
+include <src/key_sizes.scad>
+include <src/key_profiles.scad>
+include <src/key_types.scad>
+include <src/key_transformations.scad>
+include <src/key_helpers.scad>
+include <src/key_layouts.scad>

--- a/keys.scad
+++ b/keys.scad
@@ -5,15 +5,8 @@
 // without having to rely on this file. Unfortunately that means setting tons of
 // special variables, but that's a limitation of SCAD we have to work around
 
-use <src/key.scad>
+include <./includes.scad>
 
-include <src/settings.scad>
-include <src/key_sizes.scad>
-include <src/key_profiles.scad>
-include <src/key_types.scad>
-include <src/key_transformations.scad>
-include <src/key_helpers.scad>
-include <src/key_layouts.scad>
 
 // example key
 dcs_row(5) legend("⇪", size=9) key();

--- a/src/key.scad
+++ b/src/key.scad
@@ -327,7 +327,7 @@ module clearance_check() {
   }
 }
 
-module legends(depth) {
+module legends(depth=0) {
   if ($front_print_legends) {
     front_placement() {
       if (len($legends) > 0) {

--- a/src/key_profiles/dcs.scad
+++ b/src/key_profiles/dcs.scad
@@ -1,5 +1,4 @@
 module dcs_row(row=3, column=0) {
-  // names, so I don't go crazy
   $bottom_key_width = 18.16;
   $bottom_key_height = 18.16;
   $width_difference = 6;

--- a/src/layouts/gherkin/default.scad
+++ b/src/layouts/gherkin/default.scad
@@ -1,7 +1,7 @@
 include <../layout.scad>
 
 // negative numbers are used for spacing
-gherkin_mapping = [
+gherkin_default_layout = [
   [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
@@ -14,5 +14,5 @@ gherkin_default_legends = [
 ];
 
 module gherkin_default(profile) {
-  layout(gherkin_mapping, profile, legends=gherkin_default_legends, row_sculpting_offset=1, row_override=3) children();
+  layout(gherkin_default_layout, profile, legends=gherkin_default_legends, row_sculpting_offset=1, row_override=3) children();
 }

--- a/src/layouts/layout.scad
+++ b/src/layouts/layout.scad
@@ -22,7 +22,7 @@ function double_sculpted_column(column, row_length, column_sculpt_profile) =
 
 module layout(list, profile="dcs", legends=undef, row_sculpting_offset=0, row_override=undef, column_sculpt_profile="2hands", column_override=undef) {
   for (row = [0:len(list)-1]){
-    echo("**ROW**:", row);
+    /* echo("**ROW**:", row); */
     row_length = len(list[row]);
 
     for(column = column_override ? column_override : [0:len(list[row])-1]) {
@@ -31,12 +31,15 @@ module layout(list, profile="dcs", legends=undef, row_sculpting_offset=0, row_ov
       column_value = double_sculpted_column(column, row_length, column_sculpt_profile);
       column_distance = abs_sum([for (x = [0 : column]) list[row][x]]);
 
-      echo("\t**COLUMN**", "column_value", column_value, "column_distance", column_distance);
+      /* echo("\t**COLUMN**", "column_value", column_value, "column_distance", column_distance); */
 
       // supports negative values for nonexistent keys
       if (key_length >= 1) {
         translate_u(column_distance - (key_length/2), -row) {
           key_profile(profile, row_sculpting, column_value) u(key_length) legend(legends ? legends[row][column] : "") cherry() { // (row+4) % 5 + 1
+            $row = row;
+            $column = column;
+
             if (key_length == 6.25) {
               spacebar() {
                 if ($children) {
@@ -77,6 +80,40 @@ module layout(list, profile="dcs", legends=undef, row_sculpting_offset=0, row_ov
                   key();
                 }
               }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+module simple_layout(list) {
+  for (row = [0:len(list)-1]){
+    /* echo("**ROW**:", row); */
+    for(column = [0:len(list[row])-1]) {
+      key_length = list[row][column];
+      column_distance = abs_sum([for (x = [0 : column]) list[row][x]]);
+
+      /* echo("\t**COLUMN**", "column_value", column_value, "column_distance", column_distance); */
+
+      // supports negative values for nonexistent keys
+      if (key_length >= 1) {
+        translate_u(column_distance - (key_length/2), -row) {
+          u(key_length) { // (row+4) % 5 + 1
+            $row = row;
+            $column = column;
+
+            if (key_length == 6.25) {
+              spacebar() children();
+            } else if (key_length == 2.25) {
+              lshift() children();
+            } else if (key_length == 2) {
+              backspace() children();
+            } else if (key_length == 2.75) {
+              rshift() children();
+            } else {
+              children();
             }
           }
         }

--- a/src/layouts/planck/default.scad
+++ b/src/layouts/planck/default.scad
@@ -3,13 +3,21 @@ include <../layout.scad>
 // 0's are to make space for a middle row for just the spacebar so that it
 // isn't sculpted with double sculpting. the 0's in the first three rows
 // don't _need_ to be there but it's nice to keep track
-planck_layout_mapping = [
+planck_default_layout = [
   [1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 0, 2, 0, 1, 1, 1, 1, 1]
 ];
 
+planck_default_legends = [
+  [  "⇥",   "Q",   "W",   "E",   "R", "T", "Y",   "U", "I", "O", "P", "⌫"],
+  ["Esc",   "A",   "S",   "D",   "F", "G", "H",   "J", "K", "L", ";", "⏎"],
+  [  "⇧",   "Z",   "X",   "C",   "V", "B", "N",   "M", ",", ".", "/", "⇧"],
+  [ "Fn", "Ctl", "Alt", "Cmd", "Lwr",  "",  "", "RSE", "←", "↓", "↑", "→"],
+];
+
+
 module planck_default(profile, column_sculpt_profile="2hands") {
-  layout(planck_layout_mapping, profile, row_sculpting_offset=1, column_sculpt_profile=column_sculpt_profile) children();
+  layout(planck_default_layout, profile, row_sculpting_offset=1, column_sculpt_profile=column_sculpt_profile) children();
 }

--- a/src/layouts/preonic/default.scad
+++ b/src/layouts/preonic/default.scad
@@ -1,6 +1,6 @@
 include <../layout.scad>
 
-preonic_layout_mapping = [
+preonic_default_layout = [
   [1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1],
   [1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1],
@@ -8,6 +8,14 @@ preonic_layout_mapping = [
   [1, 1, 1, 1, 1, 0, 2, 0, 1, 1, 1, 1, 1]
 ];
 
+preonic_default_legends = [
+  [  "`",   "1",   "2",   "3",   "4", "5",  "", "6",  "7", "8", "9", "0", "-"],
+  [  "⇥",   "Q",   "W",   "E",   "R", "T",  "", "Y",  "U", "I", "O", "P", "⌫"],
+  ["Esc",   "A",   "S",   "D",   "F", "G",  "", "H",  "J", "K", "L", ";", "⏎"],
+  [  "⇧",   "Z",   "X",   "C",   "V", "B",  "", "N",  "M", ",", ".", "/", "⇧"],
+  [ "Fn", "Ctl", "Alt", "Cmd", "Lwr",  "",  "", "", "RSE", "←", "↓", "↑", "→"],
+];
+
 module preonic_default(profile, column_sculpt_profile="2hands") {
-  layout(preonic_layout_mapping, profile, column_sculpt_profile=column_sculpt_profile) children();
+  layout(preonic_default_layout, profile, column_sculpt_profile=column_sculpt_profile) children();
 }

--- a/src/layouts/preonic/mit.scad
+++ b/src/layouts/preonic/mit.scad
@@ -1,10 +1,21 @@
-// TODO make this use layout()
-module preonic_mit(profile) {
-  for(x = [0:1:4]) {
-    for(y=[-2.5:0.5:3]) {
-      translate_u(y * 2,-x) key_profile(profile, x,floor(y)) {
-        key();
-      }
-    }
-  }
+include <../layout.scad>
+
+preonic_mit_layout = [
+  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+];
+
+preonic_mit_legends = [
+  [  "`",   "1",   "2",   "3",   "4", "5", "6",   "7", "8", "9", "0", "-"],
+  [  "⇥",   "Q",   "W",   "E",   "R", "T", "Y",   "U", "I", "O", "P", "⌫"],
+  ["Esc",   "A",   "S",   "D",   "F", "G", "H",   "J", "K", "L", ";", "⏎"],
+  [  "⇧",   "Z",   "X",   "C",   "V", "B", "N",   "M", ",", ".", "/", "⇧"],
+  [ "Fn", "Ctl", "Alt", "Cmd", "Lwr",  "",  "", "RSE", "←", "↓", "↑", "→"],
+];
+
+module planck_mit(profile) {
+  layout(preonic_mit_layout, profile, legends=preonic_mit_legends, row_sculpting_offset=1) children();
 }


### PR DESCRIPTION
There's a ton of nontrivial-but-still-pretty-easy stuff you can do with this library. I'm gonna start throwing some of it in the examples directory.

this PR also includes `simple_layout` which is a lot less coupled than `layout` grew to be. It's harder to use but much more flexible