### PR TITLE
nominally support skinned ISO enter

### DIFF
--- a/src/key.scad
+++ b/src/key.scad
@@ -107,11 +107,12 @@ function skin_shape_slice(progress, thickness_difference, skew_this_slice, x_ske
     transform(
       rotation([tilt_this_slice,y_tilt_this_slice,0]),
         skin_key_shape([
-          total_key_width(thickness_difference),
-          total_key_height(thickness_difference),
+          total_key_width(0),
+          total_key_height(0),
           ],
           [$width_difference, $height_difference],
-          progress
+          progress,
+          thickness_difference
         )
     )
   );

--- a/src/key_types.scad
+++ b/src/key_types.scad
@@ -44,8 +44,9 @@ module iso_enter() {
   $key_height = 2;
 
   $top_tilt = 0;
+  $stem_support_type = "disable";
   $key_shape_type = "iso_enter";
-  $linear_extrude_shape = true;
+  /* $linear_extrude_shape = true; */
   $linear_extrude_height_adjustment = 19.05 * 0.5;
   // this equals (unit_length(1.5) - unit_length(1.25)) / 2
   $dish_overdraw_width = 2.38125;

--- a/src/shapes.scad
+++ b/src/shapes.scad
@@ -27,9 +27,11 @@ module key_shape(size, delta, progress = 0) {
   }
 }
 
-function skin_key_shape(size, delta, progress = 0) =
+function skin_key_shape(size, delta, progress = 0, thickness_difference) =
   $key_shape_type == "rounded_square" ?
     skin_rounded_square(size, delta, progress) :
     $key_shape_type == "sculpted_square" ?
       skin_sculpted_square_shape(size, delta, progress) :
+    $key_shape_type == "iso_enter" ?
+      skin_iso_enter_shape(size, delta, progress, thickness_difference) :
       echo("Warning: unsupported $key_shape_type for skin shape. disable skin_extrude_shape or pick a new shape");

--- a/src/shapes/ISO_enter.scad
+++ b/src/shapes/ISO_enter.scad
@@ -1,9 +1,10 @@
 // corollary is rounded_square
 // NOT 3D
+function unit_length(length) = unit * (length - 1) + 18.16;
+
 module ISO_enter_shape(size, delta, progress){
   width = size[0];
   height = size[1];
-  function unit_length(length) = unit * (length - 1) + 18.16;
 
 
   // in order to make the ISO keycap shape generic, we are going to express the
@@ -32,3 +33,23 @@ module ISO_enter_shape(size, delta, progress){
     }
   }
 }
+
+function iso_enter_vertices(width, height, width_ratio, height_ratio, wd, hd) = [
+  [                   0-wd,                     0-hd], // top right
+  [                   0-wd,               -height+hd], // bottom right
+  [-width * width_ratio+wd,               -height+hd], // bottom left
+  [-width * width_ratio+wd,-height * height_ratio+hd], // inner middle point
+  [              -width+wd,-height * height_ratio+hd], // outer middle point
+  [              -width+wd,                     0-hd]  // top left
+] + [
+  [(width * width_ratio)/2, height/2 ],
+  [(width * width_ratio)/2, height/2 ],
+  [(width * width_ratio)/2, height/2 ],
+  [(width * width_ratio)/2, height/2 ],
+  [(width * width_ratio)/2, height/2 ],
+  [(width * width_ratio)/2, height/2 ]
+];
+
+// no rounding on the corners at all
+function skin_iso_enter_shape(size, delta, progress, thickness_difference) =
+  iso_enter_vertices(size.x, size.y, unit_length(1.25) / unit_length(1.5), unit_length(1) / unit_length(2), thickness_difference/2 + delta.x * progress/2, thickness_difference/2 + delta.y * progress/2);


### PR DESCRIPTION
ISO enter has been the white whale for a while with this repo. It's concave, which means it doesn't work with `convex_hull`, the way we used to build key shapes. I added `skin_shape_hull` a while ago but due to how `skin` works, it's really hard to generate nice, rounded key shapes. However, it's probably better to have something rather than nothing.

this PR gets a skinned ISO enter MVP working. it just uses the points from the linear extruded ISO enter shape with no rounding. Due to the way side sculpting works (it's embedded in each shape) SA ISO enter doesn't look very similar, even if you ignore the corners. I think that's another PR though: shapes might need to be abstracted further to take corner radii and other junk.

I'll commit this to master once I can confirm the changes are working, I had to detangle the commit from some other stuff

oh also, the skinned ISO enter shape doesn't render _at all_ in the preview for me, but shows up just fine when rendered. it's something to do with the intersection for `dished()` but other than that I have no idea 