### PR TITLE
Add DSS profile based on spec in PDF

### DIFF
--- a/src/key_profiles.scad
+++ b/src/key_profiles.scad
@@ -10,6 +10,7 @@ include <key_profiles/g20.scad>
 include <key_profiles/hipro.scad>
 include <key_profiles/grid.scad>
 include <key_profiles/cherry.scad>
+include <key_profiles/dss.scad>
 
 // man, wouldn't it be so cool if functions were first order
 module key_profile(key_profile_type, row, column=0) {
@@ -19,6 +20,8 @@ module key_profile(key_profile_type, row, column=0) {
     oem_row(row, column) children();
   } else if (key_profile_type == "dsa") {
     dsa_row(row, column) children();
+  } else if (key_profile_type == "dss") {
+    dss_row(row, column) children();
   } else if (key_profile_type == "sa") {
     sa_row(row, column) children();
   } else if (key_profile_type == "g20") {

--- a/src/key_profiles/dss.scad
+++ b/src/key_profiles/dss.scad
@@ -1,0 +1,49 @@
+module dss_row(n=3, column=0) {
+  $key_shape_type = "sculpted_square";
+  $bottom_key_width = 18.24;
+  $bottom_key_height = 18.24;
+  $width_difference = 6;
+  $height_difference = 6;
+  $dish_type = "spherical";
+  $dish_depth = 1.2;
+  $dish_skew_x = 0;
+  $dish_skew_y = 0;
+  $top_skew = 0;
+  $height_slices = 10;
+  $enable_side_sculpting = true;
+  // might wanna change this if you don't minkowski
+  // do you even minkowski bro
+  $corner_radius = 1;
+
+  // this is _incredibly_ intensive
+  /* $rounded_key = true; */
+
+  $top_tilt_y = side_tilt(column);
+  extra_height = $double_sculpted ? extra_side_tilt_height(column) : 0;
+
+  // 5th row is usually unsculpted or the same as the row below it
+  // making a super-sculpted top row (or bottom row!) would be real easy
+  // bottom row would just be 13 tilt and 14.89 total depth
+  // top row would be something new entirely - 18 tilt maybe?
+  if (n <= 1){
+    $total_depth = 10.5 + extra_height;
+    $top_tilt = -1;
+    children();
+  } else if (n == 2) {
+    $total_depth = 8.6 + extra_height;
+    $top_tilt = 3;
+    children();
+  } else if (n == 3) {
+    $total_depth = 7.9 + extra_height;
+    $top_tilt = 8;
+    children();
+  } else if (n == 4){
+    $total_depth = 9.1 + extra_height;
+    $top_tilt = 16;
+    children();
+  } else {
+    $total_depth = 7.9 + extra_height;
+    $top_tilt = 8;
+    children();
+  }
+}


### PR DESCRIPTION
Hi!

I wanted to model some of the DSS family released by Signature Plastics in some Blender renders, but I couldn't find any models. I tried making them myself with some help, but I was really struggling. So thank you for making this repository!

I don't have any DSS keycaps and I haven't printed these. I just copied the SA family and adjusted the keycaps to match what is detailed in this PDF: https://pimpmykeyboard.com/content/DSS_Family_Updated.pdf

As the heights of each key are not specified, I estimated using the measure tool in Adobe Illustrator on the PDF. If anyone has a better way to get the exact height of the keys, please let me know.

Here is the profile from the side in the spec:
<img width="1111" alt="Screen Shot 2020-08-11 at 9 56 33 AM" src="https://user-images.githubusercontent.com/232327/89913155-fdfe7a80-dbb8-11ea-8515-e4a115593dc9.png">

And here is the render of those in OpenSCAD:
![keys](https://user-images.githubusercontent.com/232327/89913218-11114a80-dbb9-11ea-8ba7-973e4affe96b.png)

Please let me know if you have any improvements to make these more accurate!