### PR TITLE
Add (experimental) Kailh Choc support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ CHANGELOG:
     * side-printed keycaps are first class! you can use the `sideways()` modifier to set up sideways keycaps that have flat sides to print on.
     * it's much easier to make quick artisans now that the inside of the keycap is differenced from any additive features placed on top
     * `$linear_extrude_shape` and `$skin_extrude_shape` retired in favor of `$hull_shape_type`
-    * still todo: add a magic scaling variable so you can scale the whole world up, see if that fixes degeneracy
-    * still todo: rejigger supports
-    * still todo: rejigger inner shape. maybe just always make it flat
+    * added regular_polygon shape and octagonal and hexagonal key profiles
+    * added beta kailh choc
+    * Finally got ISO Enter working correctly!
+    * STILL TODO:
+      * add a magic scaling variable so you can scale the whole world up, see if that fixes degeneracy
+      * Make flat stem support default
+      * make flat inner shape default
+      * new_key_structure changes doesn't take into account support stems properly; fix
+      * support repositioning to print on the back surface of the keycap
+      * implement regular polygon for skin extrusions
+      * switch to skin-shaped extrusions by default
+      * kailh choc has a non-square key unit; should I get that working for layouts etc? 

--- a/customizer.scad
+++ b/customizer.scad
@@ -861,9 +861,31 @@ module box_cherry(slop) {
   children();
 }
 
-module choc(slop) {
-  $stem_slop = slop ? slop : $stem_slop;
+module choc(slop = 0.05) {
+  echo("WARN:\n\n * choc support is experimental.\n * $stem_slop is overridden.\n * it is also recommended to print them upside down if you can\n\n");
+  $stem_throw = 3;
+  $stem_slop = slop;
+
+  $bottom_key_width = 18;
+  $bottom_key_height = 17;
+
   $stem_type = "choc";
+  children();
+}
+
+// a hacky way to make "low profile" keycaps
+module low_profile() {
+  $width_difference = $width_difference / 1.5;
+  $height_difference = $height_difference / 1.5;
+  // helps tilted keycaps not have holes if worst comes to worst
+  $inner_shape_type = "dished";
+
+  $top_tilt = $top_tilt / 1.25;
+
+  $total_depth = ($total_depth / 2) < 7 ? 7 : $total_depth / 2;
+
+  // just to make sure
+  $stem_throw = 3;
   children();
 }
 
@@ -933,14 +955,6 @@ module debug() {
   $quaternary_color = [0.5,0.5,0.5,0.2];
 
   %children();
-}
-
-module low_profile() {
-  /* $total_depth = 5.35; */
-  /* extra ugly hack right now to make sure we don't generate keycaps with insufficient throw */
-  /* $total_depth = ($total_depth / 2) < 6 ? 6 : $total_depth / 2; */
-  $stem_throw = 3;
-  children();
 }
 module arrows(profile, rows = [4,4,4,3]) {
   positions = [[0, 0], [1, 0], [2, 0], [1, 1]];
@@ -2095,11 +2109,21 @@ module cherry_stabilizer_stem(depth, slop) {
     inside_cherry_stabilizer_cross(slop);
   }
 }
+separation = 5.7;
+
+positions = [
+  [separation/2, 0],
+  [-separation/2, 0],
+];
+
 module choc_stem(depth, slop){
-  echo("slop");
-  echo(slop);
-  translate([-5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop/2, depth], center=true);
-  translate([5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop/2, depth], center=true);
+  for (position=positions) {
+    translate([position.x,position.y, depth/2]) single_choc_stem(depth, slop);
+  }
+}
+
+module single_choc_stem(depth, slop) {
+  cube([$choc_stem.x - slop, $choc_stem.y - slop, depth], center=true);
 }
 
 
@@ -2617,7 +2641,7 @@ module tines_support(stem_type, stem_support_height, slop) {
   } else if (stem_type == "alps"){
     centered_tines(stem_support_height);
   } else if (stem_type == "choc"){
-    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness)+$wall_thickness/4, 0.5, $stem_support_height], center = true);
+    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness)+$wall_thickness/4, 0.42, $stem_support_height], center = true);
     /* translate([-5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
     /* translate([5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
   }
@@ -2974,14 +2998,13 @@ module flared(stem_type, loft, height) {
         }
       }
     } else if (stem_type == "choc") {
-      alps_scale = [scale_for_45(height, $choc_stem[0]), scale_for_45(height, $choc_stem[1])];
-      translate([-5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
-        square($choc_stem - [$stem_slop/2, $stem_slop/2], center=true);
+      // single support, just the stem
+      new_choc_scale = [scale_for_45(height, $choc_stem[0] + 5.7 - $stem_slop), scale_for_45(height, $choc_stem[1])];
+      translate([0,0,0]) linear_extrude(height=height, scale = new_choc_scale){
+        // TODO make a choc_stem() function so it can build in the slop
+        square([$choc_stem[0] + 5.7 - $stem_slop, $choc_stem[1] - $stem_slop], center=true);
       }
 
-      translate([5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
-        square($choc_stem - [$stem_slop/2, $stem_slop/2], center=true);
-      }
     } else {
       // always render cherry if no stem type. this includes stem_type = false!
       // this avoids a bug where the keycap is rendered filled when not desired

--- a/customizer.scad
+++ b/customizer.scad
@@ -178,6 +178,9 @@ $inset_legend_depth = 0.2;
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
+// Dimensions of choc stem
+$choc_stem = [1.2, 3];
+
 // Enable stabilizer stems, to hold onto your cherry or costar stabilizers
 $stabilizer_type = "costar_stabilizer"; // [costar_stabilizer, cherry_stabilizer, disable]
 
@@ -858,6 +861,12 @@ module box_cherry(slop) {
   children();
 }
 
+module choc(slop) {
+  $stem_slop = slop ? slop : $stem_slop;
+  $stem_type = "choc";
+  children();
+}
+
 module flared_support() {
   $support_type = "flared";
   children();
@@ -924,6 +933,14 @@ module debug() {
   $quaternary_color = [0.5,0.5,0.5,0.2];
 
   %children();
+}
+
+module low_profile() {
+  /* $total_depth = 5.35; */
+  /* extra ugly hack right now to make sure we don't generate keycaps with insufficient throw */
+  /* $total_depth = ($total_depth / 2) < 6 ? 6 : $total_depth / 2; */
+  $stem_throw = 3;
+  children();
 }
 module arrows(profile, rows = [4,4,4,3]) {
   positions = [[0, 0], [1, 0], [2, 0], [1, 1]];
@@ -2078,6 +2095,12 @@ module cherry_stabilizer_stem(depth, slop) {
     inside_cherry_stabilizer_cross(slop);
   }
 }
+module choc_stem(depth, slop){
+  echo("slop");
+  echo(slop);
+  translate([-5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop/2, depth], center=true);
+  translate([5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop/2, depth], center=true);
+}
 
 
 //whole stem, alps or cherry, trimmed to fit
@@ -2094,6 +2117,8 @@ module stem(stem_type, depth, slop){
       filled_stem();
     } else if (stem_type == "cherry_stabilizer") {
       cherry_stabilizer_stem(depth, slop);
+    } else if (stem_type == "choc") {
+      choc_stem(depth, slop);
     } else if (stem_type == "disable") {
       children();
     } else {
@@ -2321,6 +2346,18 @@ module brim_support(stem_type, stem_support_height, slop) {
       }
 
       inside_cherry_cross(slop);
+    }
+  } else if(stem_type == "choc") {
+    translate([-5.7/2,0,0]) linear_extrude(height=stem_support_height) {
+      offset(r=1){
+        square($choc_stem + [3,3], center=true);
+      }
+    }
+
+    translate([5.7/2,0,0]) linear_extrude(height=stem_support_height) {
+      offset(r=1){
+        square($choc_stem + [3,3], center=true);
+      }
     }
   }
 }
@@ -2579,6 +2616,10 @@ module tines_support(stem_type, stem_support_height, slop) {
     }
   } else if (stem_type == "alps"){
     centered_tines(stem_support_height);
+  } else if (stem_type == "choc"){
+    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness)+$wall_thickness/4, 0.5, $stem_support_height], center = true);
+    /* translate([-5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
+    /* translate([5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
   }
 }
 
@@ -2931,6 +2972,15 @@ module flared(stem_type, loft, height) {
         offset(r=1){
           square(outer_cherry_stabilizer_stem($stem_slop) - [2,2], center=true);
         }
+      }
+    } else if (stem_type == "choc") {
+      alps_scale = [scale_for_45(height, $choc_stem[0]), scale_for_45(height, $choc_stem[1])];
+      translate([-5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
+        square($choc_stem - [$stem_slop/2, $stem_slop/2], center=true);
+      }
+
+      translate([5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
+        square($choc_stem - [$stem_slop/2, $stem_slop/2], center=true);
       }
     } else {
       // always render cherry if no stem type. this includes stem_type = false!
@@ -4472,6 +4522,9 @@ $inset_legend_depth = 0.2;
 
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
+
+// Dimensions of choc stem
+$choc_stem = [1.2, 3];
 
 // Enable stabilizer stems, to hold onto your cherry or costar stabilizers
 $stabilizer_type = "costar_stabilizer"; // [costar_stabilizer, cherry_stabilizer, disable]

--- a/keys.scad
+++ b/keys.scad
@@ -8,15 +8,13 @@
 include <./includes.scad>
 
 
+// example key
+dcs_row(5) legend("⇪", size=9) key();
 
+// example row
+/* for (x = [0:1:4]) {
+  translate_u(0,-x) dcs_row(x) key();
+} */
 
-u(1) choc() {
-  flared_support()  tined_stem_support() sa_row(1){
-    $stem_support_height = 2;
-    low_profile() {
-      key();
-    }
-  }
-}
-
-/* translate_u(1,0) u(1) choc() row_profile("oem") low_profile() key(); */
+// example layout
+/* preonic_default("dcs"); */

--- a/keys.scad
+++ b/keys.scad
@@ -8,13 +8,15 @@
 include <./includes.scad>
 
 
-// example key
-dcs_row(5) legend("⇪", size=9) key();
 
-// example row
-/* for (x = [0:1:4]) {
-  translate_u(0,-x) dcs_row(x) key();
-} */
 
-// example layout
-/* preonic_default("dcs"); */
+u(1) choc() {
+  tined_stem_support() sa_row(1){
+    $stem_support_height = 2;
+    low_profile() {
+      key();
+    }
+  }
+}
+
+/* translate_u(1,0) u(1) choc() row_profile("oem") low_profile() key(); */

--- a/keys.scad
+++ b/keys.scad
@@ -11,7 +11,7 @@ include <./includes.scad>
 
 
 u(1) choc() {
-  tined_stem_support() sa_row(1){
+  flared_support()  tined_stem_support() sa_row(1){
     $stem_support_height = 2;
     low_profile() {
       key();

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -109,9 +109,31 @@ module box_cherry(slop) {
   children();
 }
 
-module choc(slop) {
-  $stem_slop = slop ? slop : $stem_slop;
+module choc(slop = 0.05) {
+  echo("WARN:\n\n * choc support is experimental.\n * $stem_slop is overridden.\n * it is also recommended to print them upside down if you can\n\n");
+  $stem_throw = 3;
+  $stem_slop = slop;
+
+  $bottom_key_width = 18;
+  $bottom_key_height = 17;
+
   $stem_type = "choc";
+  children();
+}
+
+// a hacky way to make "low profile" keycaps
+module low_profile() {
+  $width_difference = $width_difference / 1.5;
+  $height_difference = $height_difference / 1.5;
+  // helps tilted keycaps not have holes if worst comes to worst
+  $inner_shape_type = "dished";
+
+  $top_tilt = $top_tilt / 1.25;
+
+  $total_depth = ($total_depth / 2) < 7 ? 7 : $total_depth / 2;
+
+  // just to make sure
+  $stem_throw = 3;
   children();
 }
 
@@ -181,12 +203,4 @@ module debug() {
   $quaternary_color = [0.5,0.5,0.5,0.2];
 
   %children();
-}
-
-module low_profile() {
-  /* $total_depth = 5.35; */
-  /* extra ugly hack right now to make sure we don't generate keycaps with insufficient throw */
-  /* $total_depth = ($total_depth / 2) < 6 ? 6 : $total_depth / 2; */
-  $stem_throw = 3;
-  children();
 }

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -109,6 +109,12 @@ module box_cherry(slop) {
   children();
 }
 
+module choc(slop) {
+  $stem_slop = slop ? slop : $stem_slop;
+  $stem_type = "choc";
+  children();
+}
+
 module flared_support() {
   $support_type = "flared";
   children();
@@ -175,4 +181,12 @@ module debug() {
   $quaternary_color = [0.5,0.5,0.5,0.2];
 
   %children();
+}
+
+module low_profile() {
+  /* $total_depth = 5.35; */
+  /* extra ugly hack right now to make sure we don't generate keycaps with insufficient throw */
+  /* $total_depth = ($total_depth / 2) < 6 ? 6 : $total_depth / 2; */
+  $stem_throw = 3;
+  children();
 }

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -163,6 +163,9 @@ $inset_legend_depth = 0.2;
 // Dimensions of alps stem
 $alps_stem = [4.45, 2.25];
 
+// Dimensions of choc stem
+$choc_stem = [1.2, 3];
+
 // Enable stabilizer stems, to hold onto your cherry or costar stabilizers
 $stabilizer_type = "costar_stabilizer"; // [costar_stabilizer, cherry_stabilizer, disable]
 

--- a/src/stem_supports/brim.scad
+++ b/src/stem_supports/brim.scad
@@ -43,5 +43,17 @@ module brim_support(stem_type, stem_support_height, slop) {
 
       inside_cherry_cross(slop);
     }
+  } else if(stem_type == "choc") {
+    translate([-5.7/2,0,0]) linear_extrude(height=stem_support_height) {
+      offset(r=1){
+        square($choc_stem + [3,3], center=true);
+      }
+    }
+
+    translate([5.7/2,0,0]) linear_extrude(height=stem_support_height) {
+      offset(r=1){
+        square($choc_stem + [3,3], center=true);
+      }
+    }
   }
 }

--- a/src/stem_supports/tines.scad
+++ b/src/stem_supports/tines.scad
@@ -77,5 +77,9 @@ module tines_support(stem_type, stem_support_height, slop) {
     }
   } else if (stem_type == "alps"){
     centered_tines(stem_support_height);
+  } else if (stem_type == "choc"){
+    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness)+$wall_thickness/4, 0.5, $stem_support_height], center = true);
+    /* translate([-5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
+    /* translate([5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
   }
 }

--- a/src/stem_supports/tines.scad
+++ b/src/stem_supports/tines.scad
@@ -78,7 +78,7 @@ module tines_support(stem_type, stem_support_height, slop) {
   } else if (stem_type == "alps"){
     centered_tines(stem_support_height);
   } else if (stem_type == "choc"){
-    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness)+$wall_thickness/4, 0.5, $stem_support_height], center = true);
+    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness)+$wall_thickness/4, 0.42, $stem_support_height], center = true);
     /* translate([-5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
     /* translate([5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
   }

--- a/src/stems.scad
+++ b/src/stems.scad
@@ -4,6 +4,7 @@ include <stems/box_cherry.scad>
 include <stems/alps.scad>
 include <stems/filled.scad>
 include <stems/cherry_stabilizer.scad>
+include <stems/choc.scad>
 
 
 //whole stem, alps or cherry, trimmed to fit
@@ -20,6 +21,8 @@ module stem(stem_type, depth, slop){
       filled_stem();
     } else if (stem_type == "cherry_stabilizer") {
       cherry_stabilizer_stem(depth, slop);
+    } else if (stem_type == "choc") {
+      choc_stem(depth, slop);
     } else if (stem_type == "disable") {
       children();
     } else {

--- a/src/stems/choc.scad
+++ b/src/stems/choc.scad
@@ -1,6 +1,5 @@
 module choc_stem(depth, slop){
-  echo("slop");
-  echo(slop);
-  translate([-5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop, depth], center=true);
-  translate([5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop, depth], center=true);
+
+  translate([-5.7/2, 0, depth/2]) cube([1.2 - slop, 3 - slop / 2, depth], center=true);
+  translate([5.7/2, 0, depth/2]) cube([1.2 - slop, 3 - slop / 2, depth], center=true);
 }

--- a/src/stems/choc.scad
+++ b/src/stems/choc.scad
@@ -1,5 +1,16 @@
-module choc_stem(depth, slop){
+separation = 5.7;
 
-  translate([-5.7/2, 0, depth/2]) cube([1.2 - slop, 3 - slop / 2, depth], center=true);
-  translate([5.7/2, 0, depth/2]) cube([1.2 - slop, 3 - slop / 2, depth], center=true);
+positions = [
+  [separation/2, 0],
+  [-separation/2, 0],
+];
+
+module choc_stem(depth, slop){
+  for (position=positions) {
+    translate([position.x,position.y, depth/2]) single_choc_stem(depth, slop);
+  }
+}
+
+module single_choc_stem(depth, slop) {
+  cube([$choc_stem.x - slop, $choc_stem.y - slop, depth], center=true);
 }

--- a/src/stems/choc.scad
+++ b/src/stems/choc.scad
@@ -1,6 +1,6 @@
 module choc_stem(depth, slop){
   echo("slop");
   echo(slop);
-  translate([-5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop/2, depth], center=true);
-  translate([5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop/2, depth], center=true);
+  translate([-5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop, depth], center=true);
+  translate([5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop, depth], center=true);
 }

--- a/src/stems/choc.scad
+++ b/src/stems/choc.scad
@@ -1,0 +1,6 @@
+module choc_stem(depth, slop){
+  echo("slop");
+  echo(slop);
+  translate([-5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop/2, depth], center=true);
+  translate([5.7/2, 0, depth/2]) cube([1.2 - slop/2, 3 - slop/2, depth], center=true);
+}

--- a/src/supports/flared.scad
+++ b/src/supports/flared.scad
@@ -40,6 +40,15 @@ module flared(stem_type, loft, height) {
           square(outer_cherry_stabilizer_stem($stem_slop) - [2,2], center=true);
         }
       }
+    } else if (stem_type == "choc") {
+      alps_scale = [scale_for_45(height, $choc_stem[0]), scale_for_45(height, $choc_stem[1])];
+      translate([-5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
+        square($choc_stem - [$stem_slop/2, $stem_slop/2], center=true);
+      }
+
+      translate([5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
+        square($choc_stem - [$stem_slop/2, $stem_slop/2], center=true);
+      }
     } else {
       // always render cherry if no stem type. this includes stem_type = false!
       // this avoids a bug where the keycap is rendered filled when not desired

--- a/src/supports/flared.scad
+++ b/src/supports/flared.scad
@@ -41,15 +41,33 @@ module flared(stem_type, loft, height) {
         }
       }
     } else if (stem_type == "choc") {
-      alps_scale = [scale_for_45(height, $choc_stem[0]), scale_for_45(height, $choc_stem[1])];
-      translate([-5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
+      choc_scale = [scale_for_45(height, $choc_stem[0]), scale_for_45(height, $choc_stem[1])];
+      // double support
+      /*
+      translate([-5.7/2,0,0]) linear_extrude(height=height, scale = choc_scale){
         // TODO make a choc_stem() function so it can build in the slop
-        square($choc_stem - [$stem_slop/2, $stem_slop], center=true);
+        square($choc_stem - [$stem_slop, $stem_slop], center=true);
       }
 
-      translate([5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
-        square($choc_stem - [$stem_slop/2, $stem_slop], center=true);
+      translate([5.7/2,0,0]) linear_extrude(height=height, scale = choc_scale){
+        square($choc_stem - [$stem_slop, $stem_slop], center=true);
+      } */
+
+      // single support, full width
+
+      /* translate([0,0,0]) linear_extrude(height=height, scale = choc_scale){
+        // TODO make a choc_stem() function so it can build in the slop
+        square([total_key_width($wall_thickness), $choc_stem[1] - $stem_slop], center=true);
+      } */
+
+
+      // single support, just the stem
+      new_choc_scale = [scale_for_45(height, $choc_stem[0] + 5.7 - $stem_slop), scale_for_45(height, $choc_stem[1])];
+      translate([0,0,0]) linear_extrude(height=height, scale = new_choc_scale){
+        // TODO make a choc_stem() function so it can build in the slop
+        square([$choc_stem[0] + 5.7 - $stem_slop, $choc_stem[1] - $stem_slop], center=true);
       }
+
     } else {
       // always render cherry if no stem type. this includes stem_type = false!
       // this avoids a bug where the keycap is rendered filled when not desired

--- a/src/supports/flared.scad
+++ b/src/supports/flared.scad
@@ -41,26 +41,6 @@ module flared(stem_type, loft, height) {
         }
       }
     } else if (stem_type == "choc") {
-      choc_scale = [scale_for_45(height, $choc_stem[0]), scale_for_45(height, $choc_stem[1])];
-      // double support
-      /*
-      translate([-5.7/2,0,0]) linear_extrude(height=height, scale = choc_scale){
-        // TODO make a choc_stem() function so it can build in the slop
-        square($choc_stem - [$stem_slop, $stem_slop], center=true);
-      }
-
-      translate([5.7/2,0,0]) linear_extrude(height=height, scale = choc_scale){
-        square($choc_stem - [$stem_slop, $stem_slop], center=true);
-      } */
-
-      // single support, full width
-
-      /* translate([0,0,0]) linear_extrude(height=height, scale = choc_scale){
-        // TODO make a choc_stem() function so it can build in the slop
-        square([total_key_width($wall_thickness), $choc_stem[1] - $stem_slop], center=true);
-      } */
-
-
       // single support, just the stem
       new_choc_scale = [scale_for_45(height, $choc_stem[0] + 5.7 - $stem_slop), scale_for_45(height, $choc_stem[1])];
       translate([0,0,0]) linear_extrude(height=height, scale = new_choc_scale){

--- a/src/supports/flared.scad
+++ b/src/supports/flared.scad
@@ -43,11 +43,12 @@ module flared(stem_type, loft, height) {
     } else if (stem_type == "choc") {
       alps_scale = [scale_for_45(height, $choc_stem[0]), scale_for_45(height, $choc_stem[1])];
       translate([-5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
-        square($choc_stem - [$stem_slop/2, $stem_slop/2], center=true);
+        // TODO make a choc_stem() function so it can build in the slop
+        square($choc_stem - [$stem_slop/2, $stem_slop], center=true);
       }
 
       translate([5.7/2,0,0]) linear_extrude(height=height, scale = alps_scale){
-        square($choc_stem - [$stem_slop/2, $stem_slop/2], center=true);
+        square($choc_stem - [$stem_slop/2, $stem_slop], center=true);
       }
     } else {
       // always render cherry if no stem type. this includes stem_type = false!


### PR DESCRIPTION
I've had these changes sitting on a branch for a while but hadn't published them, as the stems kept snapping off. I had success printing [kailh choc rotators](https://www.thingiverse.com/thing:4557142) though, so I figured I'd port the numbers over from that and finally get kailh stems out the door!

They're the exact same numbers. I think the biggest difference is the rotators were printed with the stems facing up, whereas I was printing keycaps with the stems facing down (touching the build surface). It's either that or the incredibly slight chamfer I was too lazy to reproduce.

![image](https://user-images.githubusercontent.com/510867/94647063-b2fe0b00-02bd-11eb-8e0a-66f40dc0a114.png)

From top-left to bottom-right we have dcs, oem, dsa, sa and hipro in "low profile" configuration. `low_profile()` is mostly a hack to get ok-looking choc keycaps working. There's a min height of 7mm, after that the height, top_tilt and width_difference and height_difference are all divided by magic numbers to create keycaps that are significantly shorter but don't look squashed, too similar, or have the dish cut through the throw of the stem (which can happen for large values of top_tilt).

using `choc()` automatically changes the bottom_key_width and bottom_key_height to 18x17mm, which might be surprising. Kailh switches expect an 18x17mm key unit, but some / many kailh or multi-switch PCBs use 19x19. I made the executive decision to make them look good within the 17x18 by default, so that nobody accidentally goes and prints a bunch of keycaps that don't fit their board. You could scale the bottom_key_width and bottom_key_height to fit inside the 18x17mm box, but that will just look bad on both types of boards instead. Likewise, if you have a 19x19 board you can just reassign the values in a function below the `choc()` declaration.