### PR TITLE
Add slightly disappointing auto-placement functionality

### DIFF
--- a/customizer.scad
+++ b/customizer.scad
@@ -956,6 +956,19 @@ module debug() {
 
   %children();
 }
+
+// auto-place children in a grid.
+// For this to work all children have to be single keys, no for loops etc
+module auto_place() {
+  num_children = $children;
+  row_size = round(pow(num_children, 0.5));
+
+  for (child_index = [0:num_children-1]) {
+    x = child_index % row_size;
+    y = floor(child_index / row_size);
+    translate_u(x,-y) children(child_index);
+  }
+}
 module arrows(profile, rows = [4,4,4,3]) {
   positions = [[0, 0], [1, 0], [2, 0], [1, 1]];
   legends = ["←", "↓", "→", "↑"];

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -204,3 +204,16 @@ module debug() {
 
   %children();
 }
+
+// auto-place children in a grid.
+// For this to work all children have to be single keys, no for loops etc
+module auto_place() {
+  num_children = $children;
+  row_size = round(pow(num_children, 0.5));
+
+  for (child_index = [0:num_children-1]) {
+    x = child_index % row_size;
+    y = floor(child_index / row_size);
+    translate_u(x,-y) children(child_index);
+  }
+}


### PR DESCRIPTION
It'd be cool if you could auto-place keycaps. It'd be great for onboarding since you wouldn't have to learn about translate_u, it'd be great for just screwing around without caring about placement, it'd also be great for automatically plating a layout. Some slicers can separate objects and auto-place them, but almost all of them leave way too large of clearance gaps in between.

Turns out, you can auto-place things in OpenSCAD! but only direct children. So no for loops or any scoping whatsoever.

It's still cool, this code:

```
// example key
auto_place() {
  dcs_row(5) legend("a", size=9) key();
  dcs_row(5) legend("b", size=9) key();
  dcs_row(5) legend("c", size=9) key();
  dcs_row(5) legend("d", size=9) key();
  dcs_row(5) legend("e", size=9) key();
  dcs_row(5) legend("f", size=9) key();
  dcs_row(5) legend("g", size=9) key();
  dcs_row(5) legend("h", size=9) key();
  dcs_row(5) legend("i", size=9) key();
  dcs_row(5) legend("j", size=9) key();
}
```

makes this output:

![image](https://user-images.githubusercontent.com/510867/94741871-cf905680-0342-11eb-8fd0-6a5d19ec731e.png)


but it's not nearly as cool as it could be. I spent a couple hours last night seeing if there was a way around this but I knew it was probably foolhardy given the whole compiled nature of openSCAD. The best thing I came up with was you could recompile to make `rands` spit out the same set of numbers every time that you could use to index calls to `rands`, which is... definitely something.