### PR TITLE
Keyset for Commodore 64 based on SA profile

### DIFF
--- a/customizer.scad
+++ b/customizer.scad
@@ -86,6 +86,7 @@ $stem_throw = 4;
 // Diameter of the outside of the rounded cherry stem
 $rounded_cherry_stem_d = 5.5;
 
+$c64_stem_d = 5;
 
 // How much higher the stem is than the bottom of the keycap.
 // Inset stem requires support but is more accurate in some profiles

--- a/examples/commodore_64_keyset.scat
+++ b/examples/commodore_64_keyset.scat
@@ -1,0 +1,4 @@
+include <./includes.scad>
+
+c64_default("sa") c64() key();
+

--- a/keys.scad
+++ b/keys.scad
@@ -9,7 +9,17 @@ include <./includes.scad>
 
 
 // example key
-dcs_row(5) legend("⇪", size=9) key();
+dsa_row(1) legend("Q", size=9) c64() key();
+
+translate([-1.5/2,-1.5/2,0])
+cube([1.5,1.5,1.5]);
+
+
+translate([-5/2,-1.5/2,0])
+cube([5,1.5,1.5]);
+
+translate([-0.75,-5/2,0])
+cube([1.5,5,1.5]);
 
 // example row
 /* for (x = [0:1:4]) {

--- a/src/functions.scad
+++ b/src/functions.scad
@@ -7,6 +7,8 @@ include <constants.scad>
 // cherry stem dimensions
 function outer_cherry_stem(slop) = [7.2 - slop * 2, 5.5 - slop * 2];
 
+function outer_c64_stem(slop) = [7.2 - slop * 2, 7.2 - slop * 2];
+
 // cherry stabilizer stem dimensions
 function outer_cherry_stabilizer_stem(slop) = [4.85 - slop * 2, 6.05 - slop * 2];
 
@@ -20,6 +22,14 @@ function cherry_cross(slop, extra_vertical = 0) = [
   // vertical tine
   [1.15 + slop / 3, 4.23 + extra_vertical + slop / 3 + SMALLEST_POSSIBLE],
 ];
+
+function c64_cross(slop, extra_vertical = 0) = [
+  // horizontal tine
+  [5.5 + slop, 1.7 + slop / 3],
+  // vertical tine
+  [1.7 + slop / 3, 5.23 + extra_vertical + slop / 3 + SMALLEST_POSSIBLE],
+];
+
 
 // actual mm key width and height
 function total_key_width(delta = 0) = $bottom_key_width + $unit * ($key_length - 1) - delta;

--- a/src/functions.scad
+++ b/src/functions.scad
@@ -25,11 +25,17 @@ function cherry_cross(slop, extra_vertical = 0) = [
 
 function c64_cross(slop, extra_vertical = 0) = [
   // horizontal tine
-  [5.5 + slop, 1.7 + slop / 3],
+  [5.0 + slop, 1.5 + slop / 3],
   // vertical tine
-  [1.7 + slop / 3, 5.23 + extra_vertical + slop / 3 + SMALLEST_POSSIBLE],
+  [1.5 + slop / 3, 5.0 + extra_vertical + slop / 3 + SMALLEST_POSSIBLE],
 ];
 
+function c64_inner_cross(slop, extra_vertical = 0) = [
+  // horizontal tine
+  [5.4 + slop, 1.7 + slop / 3],
+  // vertical tine
+  [1.7 + slop / 3, 5.4 + extra_vertical + slop / 3 + SMALLEST_POSSIBLE],
+];
 
 // actual mm key width and height
 function total_key_width(delta = 0) = $bottom_key_width + $unit * ($key_length - 1) - delta;

--- a/src/key_layouts.scad
+++ b/src/key_layouts.scad
@@ -1,5 +1,7 @@
 include <layouts/layout.scad>
 
+include <layouts/c64/default.scad>
+
 include <layouts/preonic/default.scad>
 include <layouts/preonic/mit.scad>
 

--- a/src/key_sizes.scad
+++ b/src/key_sizes.scad
@@ -33,6 +33,11 @@ module 6_25u() {
   u(6.25) children();
 }
 
+module 9u() {
+  u(9) children();
+}
+
+
 // key height functions
 
 module uh(u=1) {
@@ -66,4 +71,8 @@ module 2_75uh() {
 
 module 6_25uh() {
   uh(6.25) children();
+}
+
+module 9uh() {
+  uh(9) children();
 }

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -92,6 +92,12 @@ module blank() {
   children();
 }
 
+module c64(slop) {
+  $stem_slop = slop ? slop : $stem_slop;
+  $stem_type = "c64";
+  children();
+}
+
 module cherry(slop) {
   $stem_slop = slop ? slop : $stem_slop;
   $stem_type = "cherry";

--- a/src/key_types.scad
+++ b/src/key_types.scad
@@ -6,6 +6,12 @@ module spacebar() {
   6_25u() stabilized(mm=50) children();
 }
 
+module c64_spacebar() {
+  $inverted_dish = true;
+  $dish_type = "sideways cylindrical";
+  9u() stabilized(mm=50) children();
+}
+
 module lshift() {
   2_25u() stabilized() children();
 }

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -4,7 +4,7 @@
 $key_length = 1.0; // Range not working in thingiverse customizer atm [1:0.25:16]
 
 // What type of stem you want. Most people want Cherry.
-$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, disable]
+$stem_type = "cherry";  // [cherry, alps, rounded_cherry, box_cherry, filled, c64, disable]
 
 // The stem is the hardest part to print, so this variable controls how much 'slop' there is in the stem
 // if your keycaps stick in the switch raise this value
@@ -67,10 +67,11 @@ $top_skew_x = 0;
 /* [Stem] */
 
 // How far the throw distance of the switch is. determines how far the 'cross' in the cherry switch digs into the stem, and how long the keystem needs to be before supports can start. luckily, alps and cherries have a pretty similar throw. can modify to have stouter keycaps for low profile switches, etc
-$stem_throw = 4;
+$stem_throw = 5;
 // Diameter of the outside of the rounded cherry stem
 $rounded_cherry_stem_d = 5.5;
 
+$c64_stem_d = 9;
 
 // How much higher the stem is than the bottom of the keycap.
 // Inset stem requires support but is more accurate in some profiles
@@ -119,7 +120,8 @@ $c64_bevel = true;
 // How tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
 $stem_support_height = .8;
 // Font used for text
-$font="DejaVu Sans Mono:style=Book";
+//$font="DejaVu Sans Mono:style=Book";
+$font="Trade Gothic Bold Condensed";
 // Whether or not to render fake keyswitches to check clearances
 $clearance_check = false;
 // Should be faster, also required for concave shapes

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -114,6 +114,7 @@ $dish_overdraw_height = 0;
 /* [Misc] */
 // There's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
 $cherry_bevel = true;
+$c64_bevel = true;
 
 // How tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
 $stem_support_height = .8;

--- a/src/stem_supports/brim.scad
+++ b/src/stem_supports/brim.scad
@@ -23,6 +23,11 @@ module brim_support(stem_type, stem_support_height, slop) {
       cylinder(d=$rounded_cherry_stem_d * 2, h=stem_support_height);
       inside_cherry_cross(slop);
     }
+  } else if (stem_type == "c64") {
+    difference() {
+      cylinder(d=$c64_stem_d * 2, h=stem_support_height);
+      inside_c64_cross(slop);
+    }
   } else if (stem_type == "box_cherry") {
     difference() {
       linear_extrude(height = stem_support_height){

--- a/src/stem_supports/tines.scad
+++ b/src/stem_supports/tines.scad
@@ -1,20 +1,35 @@
 include <../functions.scad>
 include <../stems/cherry.scad>
 
-module centered_tines(stem_support_height) {
+module centered_tines(stem_type,stem_support_height) {
   if ($key_length < 2) {
     translate([0,0,$stem_support_height / 2]) {
-      cube([total_key_width(), 0.5, $stem_support_height], center = true);
+      if (stem_type == "c64"){
+        cube([total_key_width()-0.5, 0.5, $stem_support_height], center = true);
+      }
+      else {
+        cube([total_key_width(), 0.5, $stem_support_height], center = true);
+      }
     }
   }
 
   translate([0,0,$stem_support_height / 2]) {
-    cube([
-      1,
-      total_key_height(),
-      $stem_support_height
-    ],
-    center = true);
+      if (stem_type == "c64"){
+          cube([
+            1,
+            total_key_height()-0.5,
+            $stem_support_height
+            ],
+            center = true);
+       }
+       else{
+          cube([
+            1,
+            total_key_height(),
+            $stem_support_height
+            ],
+            center = true);
+       }
   }
 }
 
@@ -65,17 +80,25 @@ module tines_support(stem_type, stem_support_height, slop) {
     }
   } else if (stem_type == "box_cherry") {
     difference () {
-      centered_tines(stem_support_height);
+      centered_tines(stem_type, stem_support_height);
 
       inside_cherry_cross(slop);
     }
   } else if (stem_type == "rounded_cherry") {
     difference () {
-      centered_tines(stem_support_height);
+      centered_tines(stem_type, stem_support_height);
 
       inside_cherry_cross(slop);
     }
-  } else if (stem_type == "alps"){
-    centered_tines(stem_support_height);
+
+  } else if (stem_type == "c64") {
+    difference () {
+      centered_tines(stem_type, stem_support_height);
+
+      inside_c64_cross(slop);
+    }
+  }
+  else if (stem_type == "alps"){
+    centered_tines(stem_type,stem_support_height);
   }
 }

--- a/src/stems.scad
+++ b/src/stems.scad
@@ -1,4 +1,5 @@
 include <stems/cherry.scad>
+include <stems/c64.scad>
 include <stems/rounded_cherry.scad>
 include <stems/box_cherry.scad>
 include <stems/alps.scad>
@@ -13,6 +14,8 @@ module stem(stem_type, depth, slop, throw){
       alps_stem(depth, slop, throw);
     } else if (stem_type == "cherry" || stem_type == "costar_stabilizer") {
       cherry_stem(depth, slop, throw);
+    } else if (stem_type == "c64" ) {
+      c64_stem(depth, slop, throw);
     } else if (stem_type == "rounded_cherry") {
       rounded_cherry_stem(depth, slop, throw);
     } else if (stem_type == "box_cherry") {

--- a/src/stems/c64.scad
+++ b/src/stems/c64.scad
@@ -1,0 +1,37 @@
+include <../functions.scad>
+
+// extra length to the vertical tine of the inside c64 cross
+// splits the stem into halves - allows easier fitment
+extra_vertical = 0.6;
+
+module inside_c64_cross(slop) {
+  // inside cross
+  // translation purely for aesthetic purposes, to get rid of that awful lattice
+  translate([0,0,-SMALLEST_POSSIBLE]) {
+    linear_extrude(height = $stem_throw) {
+      square(c64_cross(slop, extra_vertical)[0], center=true);
+      square(c64_cross(slop, extra_vertical)[1], center=true);
+    }
+  }
+
+  // Guides to assist insertion and mitigate first layer squishing
+  if ($c64_bevel){
+    for (i = c64_cross(slop, extra_vertical)) hull() {
+      linear_extrude(height = 0.01, center = false) offset(delta = 0.1) square(i, center=true);
+      translate([0, 0, 0.1]) linear_extrude(height = 0.01, center = false)  square(i, center=true);
+    }
+  }
+}
+
+module c64_stem(depth, slop, throw) {
+  difference(){
+    // outside shape
+    linear_extrude(height = depth) {
+      offset(r=1){
+        square(outer_c64_stem(slop) - [2,2], center=true);
+      }
+    }
+
+    inside_c64_cross($stem_inner_slop);
+  }
+}

--- a/src/stems/c64.scad
+++ b/src/stems/c64.scad
@@ -14,6 +14,14 @@ module inside_c64_cross(slop) {
     }
   }
 
+  // inner portion of the cross, c64 stems are thicker halfway to ensure keys stay put
+  translate([0,0,1.95]) {
+    linear_extrude(height = 0.6) {
+      square(c64_inner_cross(slop, extra_vertical)[0], center=true);
+      square(c64_inner_cross(slop, extra_vertical)[1], center=true);
+    }
+  }
+
   // Guides to assist insertion and mitigate first layer squishing
   if ($c64_bevel){
     for (i = c64_cross(slop, extra_vertical)) hull() {
@@ -24,13 +32,10 @@ module inside_c64_cross(slop) {
 }
 
 module c64_stem(depth, slop, throw) {
+
   difference(){
+    cylinder(d=$c64_stem_d, h=depth);
     // outside shape
-    linear_extrude(height = depth) {
-      offset(r=1){
-        square(outer_c64_stem(slop) - [2,2], center=true);
-      }
-    }
 
     inside_c64_cross($stem_inner_slop);
   }


### PR DESCRIPTION
It's a complete keycap set for Commodore 64, major changes around stem fittings.
It clicks pretty well on the stems.
I've printed this on Prusa MK3S in PLA, the results aren't great, I'd recommend using SLA printer, or printing in ABS and using acetone.