### PR TITLE
Outer cherry bevel

### DIFF
--- a/src/constants.scad
+++ b/src/constants.scad
@@ -1,3 +1,4 @@
 SMALLEST_POSSIBLE = 1/128;
 $fs = .1;
 $unit = 19.05;
+$zero = 0.01; // used to extrude 2d elements into 3d elements with "zero" height

--- a/src/key.scad
+++ b/src/key.scad
@@ -219,9 +219,9 @@ module _dish() {
 module envelope(depth_difference=0) {
   s = 1.5;
   hull(){
-    cube([total_key_width() * s, total_key_height() * s, 0.01], center = true);
+    cube([total_key_width() * s, total_key_height() * s, $zero], center = true);
     top_placement(SMALLEST_POSSIBLE + depth_difference){
-      cube([top_total_key_width() * s, top_total_key_height() * s, 0.01], center = true);
+      cube([top_total_key_width() * s, top_total_key_height() * s, $zero], center = true);
     }
   }
 }
@@ -307,12 +307,12 @@ module stems_for(positions, stem_type) {
 module cherry_keyswitch() {
   union() {
     hull() {
-      cube([15.6, 15.6, 0.01], center=true);
-      translate([0,1,5 - 0.01]) cube([10.5,9.5, 0.01], center=true);
+      cube([15.6, 15.6, $zero], center=true);
+      translate([0,1,5 - $zero]) cube([10.5,9.5, $zero], center=true);
     }
     hull() {
-      cube([15.6, 15.6, 0.01], center=true);
-      translate([0,0,-5.5]) cube([13.5,13.5,0.01], center=true);
+      cube([15.6, 15.6, $zero], center=true);
+      translate([0,0,-5.5]) cube([13.5,13.5,$zero], center=true);
     }
   }
 }

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -113,7 +113,16 @@ $dish_overdraw_height = 0;
 
 /* [Misc] */
 // There's a bevel on the cherry stems to aid insertion / guard against first layer squishing making a hard-to-fit stem.
-$cherry_bevel = true;
+// Set height to 0 to disable.
+$cherry_bevel_height = 0.5;
+$cherry_bevel_width = 0.4;
+
+// Add bevel to outside of cherry stems.  Set to 0 to disable.
+$cherry_outer_bevel_height = 0;
+$cherry_outer_bevel_width = $cherry_outer_bevel_height;
+
+// Radius of corner on cherry and box_cherry stems
+$cherry_radius = 1;
 
 // How tall in mm the stem support is, if there is any. stem support sits around the keystem and helps to secure it while printing.
 $stem_support_height = .8;

--- a/src/stems/box_cherry.scad
+++ b/src/stems/box_cherry.scad
@@ -4,10 +4,15 @@ include <cherry.scad>
 module box_cherry_stem(depth, slop, throw) {
   difference(){
     // outside shape
-    linear_extrude(height = depth) {
-      offset(r=1){
-        square(outer_box_cherry_stem(slop) - [2,2], center=true);
-      }
+    hull() {
+      translate([0,0,$cherry_outer_bevel_height])
+      linear_extrude(height = depth-$cherry_outer_bevel_height)
+      offset(r=$cherry_radius)
+      square(outer_box_cherry_stem(slop) - [$cherry_radius*2,$cherry_radius*2], center=true);
+
+      linear_extrude(height = depth)
+      offset(r=$cherry_radius-$cherry_outer_bevel_width)
+      square(outer_box_cherry_stem(slop) - [$cherry_radius*2,$cherry_radius*2], center=true);
     }
 
     // inside cross

--- a/src/stems/cherry.scad
+++ b/src/stems/cherry.scad
@@ -15,10 +15,15 @@ module inside_cherry_cross(slop) {
   }
 
   // Guides to assist insertion and mitigate first layer squishing
-  if ($cherry_bevel){
+  if ($cherry_bevel_height){
     for (i = cherry_cross(slop, extra_vertical)) hull() {
-      linear_extrude(height = $zero, center = false) offset(delta = 0.4) square(i, center=true);
-      translate([0, 0, 0.5]) linear_extrude(height = $zero, center = false)  square(i, center=true);
+      linear_extrude(height = $zero, center = false)
+      offset(delta = $cherry_bevel_width)
+      square(i, center=true);
+
+      translate([0, 0, $cherry_bevel_height-$zero])
+      linear_extrude(height = $zero, center = false)
+      square(i, center=true);
     }
   }
 }
@@ -26,10 +31,15 @@ module inside_cherry_cross(slop) {
 module cherry_stem(depth, slop, throw) {
   difference(){
     // outside shape
-    linear_extrude(height = depth) {
-      offset(r=1){
-        square(outer_cherry_stem(slop) - [2,2], center=true);
-      }
+    hull() {
+      translate([0,0,$cherry_outer_bevel_height])
+      linear_extrude(height = depth - $cherry_outer_bevel_height)
+      offset(r=$cherry_radius)
+      square(outer_cherry_stem(slop) - [$cherry_radius*2,$cherry_radius*2], center=true);
+
+      linear_extrude(height = depth, center = false)
+      offset(r=$cherry_radius-$cherry_outer_bevel_width)
+      square(outer_cherry_stem(slop) - [$cherry_radius*2,$cherry_radius*2], center=true);
     }
 
     inside_cherry_cross($stem_inner_slop);

--- a/src/stems/cherry.scad
+++ b/src/stems/cherry.scad
@@ -17,8 +17,8 @@ module inside_cherry_cross(slop) {
   // Guides to assist insertion and mitigate first layer squishing
   if ($cherry_bevel){
     for (i = cherry_cross(slop, extra_vertical)) hull() {
-      linear_extrude(height = 0.01, center = false) offset(delta = 0.4) square(i, center=true);
-      translate([0, 0, 0.5]) linear_extrude(height = 0.01, center = false)  square(i, center=true);
+      linear_extrude(height = $zero, center = false) offset(delta = 0.4) square(i, center=true);
+      translate([0, 0, 0.5]) linear_extrude(height = $zero, center = false)  square(i, center=true);
     }
   }
 }

--- a/src/stems/rounded_cherry.scad
+++ b/src/stems/rounded_cherry.scad
@@ -3,7 +3,11 @@ include <cherry.scad>
 
 module rounded_cherry_stem(depth, slop, throw) {
   difference(){
-    cylinder(d=$rounded_cherry_stem_d, h=depth);
+    hull() {
+      translate([0,0,$cherry_outer_bevel_height])
+      cylinder(d=$rounded_cherry_stem_d, h=depth-$cherry_outer_bevel_height);
+      cylinder(d=$rounded_cherry_stem_d-$cherry_outer_bevel_width*2, h=depth);
+    }
 
     // inside cross
     // translation purely for aesthetic purposes, to get rid of that awful lattice


### PR DESCRIPTION
I was having trouble fitting some key caps into Kailh box cherrys due to the outer edge.  This pull request adds an optional outer bevel for the cherry stems (box, rounded, and normal.)  

There were some hard coded numbers in the stems scad files that I couldn't identify at first so I made them constants or settings.