### PR TITLE
add alignment tool

### DIFF
--- a/includes.scad
+++ b/includes.scad
@@ -7,3 +7,4 @@ include <src/key_types.scad>
 include <src/key_transformations.scad>
 include <src/key_helpers.scad>
 include <src/key_layouts.scad>
+include <src/alignment_tool.scad>

--- a/src/alignment_tool.scad
+++ b/src/alignment_tool.scad
@@ -1,0 +1,15 @@
+include <./includes.scad>
+
+// Tool for keeping switches aligned while soldering
+// Keep the bar high enough that when the keyboard is upside down the switches can be fully depressed
+
+module alignment_tool(layout=[[1,1,1,1,1]], bar_height=$stem_throw*1.2) {
+    bar_width=unit/2;
+    simple_layout(layout) 
+    stem($stem_type, $stem_throw, $stem_slop, $stem_throw);
+    hull() {
+        simple_layout(layout) 
+        translate([-unit/2,-bar_width/2,$stem_throw])
+        cube([unit,bar_width,bar_height]);
+    }
+}


### PR DESCRIPTION
Simple solution to keep keys aligned while soldering them in using the existing stem settings. 

![PXL_20210226_055302619](https://user-images.githubusercontent.com/2530548/109427634-e356ec00-79b8-11eb-9b57-037637aadc48.jpg)

