### PR TITLE
fix tines for offset stems

### DIFF
--- a/capslock.scad
+++ b/capslock.scad
@@ -7,7 +7,14 @@
 
 include <./includes.scad>
 
-// single CAPS_LOCK key
+// set viewport
+$vpt = [ -51.76, -91.61, -87.33 ];
+$vpr = [ 55.00, 0.00, 25.00 ];
+$vpd = 839.47;
+
+// try a bunch of CAPS_LOCK keys at 4x size
+
+// single stem, centred
     u(u=1.75)
     dcs_row(2) 
     box_cherry(0.3)
@@ -16,8 +23,7 @@ include <./includes.scad>
     scale(4)
 key(); 
 
-
-// single CAPS_LOCK key
+// single stem, offset, no stabilizer
     u(u=1.75)
     dcs_row(2) 
     box_cherry(0.3)
@@ -25,10 +31,9 @@ key();
     legend("LOCK", size=2.5, position=[-0.75,0.5])
     scale(4)
 	translate_u(0,-1)
-key($stabilizers = [[6,0]],$stem_positions = [[-5, 0]]); 
+key($stem_positions = [[-5, 0]]); 
 
-
-$stabilizers = [] ;
+// single stem, offset, with one stabilizer
     u(u=1.75)
     dcs_row(2) 
     box_cherry(0.3)
@@ -36,17 +41,39 @@ $stabilizers = [] ;
     legend("LOCK", size=2.5, position=[-0.75,0.5])
     scale(4)
 	translate_u(0,-2)
-key($stem_positions = [[-5, 0]]); 
+key($stabilizers = [[6,0]],$stem_positions = [[-5, 0]]); 
 
-$stabilizers = [] ;
-    u(u=2)
+// CAPS width, with two stabilizers
+    u(u=1.75)
     dcs_row(2) 
     box_cherry(0.3)
     legend("CAPS", size=2.5, position=[-0.8,-0.5])
     legend("LOCK", size=2.5, position=[-0.8,0.5])
-    stabilized(mm=12, vertical = false, type=cherry_stabilizer[x])
+    stabilized(mm=12, vertical = false, type="cherry_stabilizer")
     scale(4)
-	translate_u(0,-3)
+    translate_u(0,-3)
+key(); 
+
+// 1.5 width, with two stabilizers
+    1_5u()
+    dcs_row(2) 
+    box_cherry(0.3)
+    legend("CAPS", size=2.5, position=[-0.70,-0.5])
+    legend("LOCK", size=2.5, position=[-0.70,0.5])
+    stabilized(mm=12, vertical = false, type="cherry_stabilizer")
+    scale(4)
+    translate_u(0,-4)
+key(); 
+
+// double width, with two stabilizers
+    u(u=2)
+    dcs_row(2) 
+    box_cherry(0.3)
+    legend("CAPS", size=2.5, position=[-0.85,-0.5])
+    legend("LOCK", size=2.5, position=[-0.85,0.5])
+    stabilized(mm=12, vertical = false, type="cherry_stabilizer")
+    scale(4)
+    translate_u(0,-5)
 key(); 
 
 // test all the stems
@@ -66,6 +93,3 @@ for (x = [0:1:4]) {
 
 // example layout
 /* preonic_default("dcs"); */
-
-
-

--- a/capslock.scad
+++ b/capslock.scad
@@ -1,0 +1,71 @@
+// the point of this file is to be a sort of DSL for constructing keycaps.
+// when you create a method chain you are just changing the parameters
+// key.scad uses, it doesn't generate anything itself until the end. This
+// lets it remain easy to use key.scad like before (except without key profiles)
+// without having to rely on this file. Unfortunately that means setting tons of
+// special variables, but that's a limitation of SCAD we have to work around
+
+include <./includes.scad>
+
+// single CAPS_LOCK key
+    u(u=1.75)
+    dcs_row(2) 
+    box_cherry(0.3)
+    legend("CAPS", size=2.5, position=[-0.75,-0.5])
+    legend("LOCK", size=2.5, position=[-0.75,0.5])
+    scale(4)
+key(); 
+
+
+// single CAPS_LOCK key
+    u(u=1.75)
+    dcs_row(2) 
+    box_cherry(0.3)
+    legend("CAPS", size=2.5, position=[-0.75,-0.5])
+    legend("LOCK", size=2.5, position=[-0.75,0.5])
+    scale(4)
+	translate_u(0,-1)
+key($stabilizers = [[6,0]],$stem_positions = [[-5, 0]]); 
+
+
+$stabilizers = [] ;
+    u(u=1.75)
+    dcs_row(2) 
+    box_cherry(0.3)
+    legend("CAPS", size=2.5, position=[-0.75,-0.5])
+    legend("LOCK", size=2.5, position=[-0.75,0.5])
+    scale(4)
+	translate_u(0,-2)
+key($stem_positions = [[-5, 0]]); 
+
+$stabilizers = [] ;
+    u(u=2)
+    dcs_row(2) 
+    box_cherry(0.3)
+    legend("CAPS", size=2.5, position=[-0.8,-0.5])
+    legend("LOCK", size=2.5, position=[-0.8,0.5])
+    stabilized(mm=12, vertical = false, type=cherry_stabilizer[x])
+    scale(4)
+	translate_u(0,-3)
+key(); 
+
+// test all the stems
+/*
+test_stems = ["cherry", "rounded_cherry", "box_cherry", "alps",  "cherry_stabilizer", "filled", "custom"];
+for (x = [0:1:4]) {
+	$stem_type = test_stems[x];
+    2u()
+    dcs_row(5) 
+    stabilized(mm=12, vertical = false, type=test_stems[x])
+    legend("CAPS LOCK", size=3, position=[-0.16,1])
+    scale(4)
+    translate_u(0,-x)
+  key();
+}
+*/
+
+// example layout
+/* preonic_default("dcs"); */
+
+
+

--- a/src/key.scad
+++ b/src/key.scad
@@ -401,6 +401,7 @@ module key(inset = false) {
 
   // both stem and support are optional
   if ($stem_type != "disable" || ($stabilizers != [] && $stabilizer_type != "disable")) {
+    inside()
     dished($keytop_thickness, $inverted_dish) {
       translate([0, 0, $stem_inset]) {
         if ($stabilizer_type != "disable") stems_for($stabilizers, $stabilizer_type);

--- a/src/stem_supports/tines.scad
+++ b/src/stem_supports/tines.scad
@@ -3,7 +3,7 @@ include <../stems/cherry.scad>
 
 module centered_tines(stem_support_height) {
   if ($key_length < 2) {
-    translate([0,0,$stem_support_height / 2]) {
+    translate([0-$stem_positions[0][0],0-$stem_positions[0][1],$stem_support_height / 2]) {
       cube([total_key_width(), 0.5, $stem_support_height], center = true);
     }
   }
@@ -26,7 +26,7 @@ module tines_support(stem_type, stem_support_height, slop) {
     difference () {
       union() {
         if ($key_length < 2) {
-          translate([0,0,$stem_support_height / 2]) {
+          translate([0+$stem_positions[0][0],0+$stem_positions[0][1],$stem_support_height / 2]) {
             cube([
               total_key_width() + extra_width*2,
               0.5,


### PR DESCRIPTION
I was messing with creating some caps lock keys, and I noticed that the support tines weren't following the offset.  this fix seemed to work, but I admit I haven't run a comprehensive test suite.