### PR TITLE
Fix typo in Printing Help section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Prints from this library are still challenging, despite all efforts to the contr
 
 1. If your stem isn't fitting in the switch, try upping the slop factor, accessed by giving your keystem function a numeric value (eg `cherry(0.5) key()`). This will lengthen the cross and decrease the overall size of the keystem. The default value is 0.3, and represents millimeters. Note that even if you have a resin printer, you should probably keep the default value; keys printed with 0 slop will barely fit on the stem.
 
-2. If your keystem breaks off the bed mid-print, you can enable a brim by adding the `brimmed()` modifier. This will give a solid base for the keystem to anchor into.
+2. If your keystem breaks off the bed mid-print, you can enable a brim by adding the `brimmed_stem_support()` modifier. This will give a solid base for the keystem to anchor into.
 
 3. If you are unsatisfied with the quality of the top surface, you can try printing the keycap on a different surface than the bottom, though it may impact the quality of the stem.
 


### PR DESCRIPTION
The printing help section referred to the `brimmed()` modifier when it should actually be `brimmed_stem_support()`