### PR TITLE
Add new ASA profile (by Akko)

### DIFF
--- a/src/key_profiles.scad
+++ b/src/key_profiles.scad
@@ -11,6 +11,7 @@ include <key_profiles/hipro.scad>
 include <key_profiles/grid.scad>
 include <key_profiles/cherry.scad>
 include <key_profiles/dss.scad>
+include <key_profiles/asa.scad>
 
 // man, wouldn't it be so cool if functions were first order
 module key_profile(key_profile_type, row, column=0) {
@@ -24,6 +25,8 @@ module key_profile(key_profile_type, row, column=0) {
     dss_row(row, column) children();
   } else if (key_profile_type == "sa") {
     sa_row(row, column) children();
+  } else if (key_profile_type == "asa") {
+    asa_row(row, column) children();
   } else if (key_profile_type == "g20") {
     g20_row(row, column) children();
   } else if (key_profile_type == "hipro") {

--- a/src/key_profiles/asa.scad
+++ b/src/key_profiles/asa.scad
@@ -1,0 +1,44 @@
+module asa_row(row=3, column = 0) {
+  $key_shape_type = "sculpted_square";
+  $bottom_key_width = 18.4;
+  $bottom_key_height = 18.4;
+  $width_difference = 5.7;
+  $height_difference = 5.7;
+  $dish_type = "spherical";
+  $dish_depth = 1;
+  $dish_skew_x = 0;
+  $dish_skew_y = 0;
+  $top_skew = 1.75;
+  $stem_inset = 1.2;
+  $height_slices = 10;
+  $corner_radius = 1;
+
+  // this is _incredibly_ intensive
+  //$rounded_key = true;
+
+  $top_tilt_y = side_tilt(column);
+  extra_height =  $double_sculpted ? extra_side_tilt_height(column) : 0;
+
+  if (row <= 1){
+    $total_depth = 10.65 + extra_height;
+    $top_tilt = 7;
+    children();
+  } else if (row == 2) {
+    $total_depth = 9.65 + extra_height;
+    $top_tilt = 3.25;
+    children();
+  } else if (row == 3) {
+    $total_depth = 10.35 + extra_height;
+    $top_tilt = 1.5;
+    children();
+  } else if (row == 4 || row == 5){
+    $total_depth = 11.9 + extra_height;
+    $top_tilt = 0.43;
+    children();
+  } else {
+    // Same as row == 3
+    $total_depth = 10.35 + extra_height;
+    $top_tilt = 1.5;
+    children();
+  }
+}

--- a/src/key_profiles/asa.scad
+++ b/src/key_profiles/asa.scad
@@ -1,11 +1,13 @@
 module asa_row(row=3, column = 0) {
   $key_shape_type = "sculpted_square";
-  $bottom_key_width = 18.4;
-  $bottom_key_height = 18.4;
-  $width_difference = 5.7;
-  $height_difference = 5.7;
+  $bottom_key_height = 18.06;
+  $bottom_key_width = 18.05;      // Default (R3)
+  $total_depth = 10.35;           // Default (R3)
+  $top_tilt = 1.5;                // Default (R3)
+  $width_difference = 5.05;
+  $height_difference = 5.56;
   $dish_type = "spherical";
-  $dish_depth = 1;
+  $dish_depth = 1.2;
   $dish_skew_x = 0;
   $dish_skew_y = 0;
   $top_skew = 1.75;
@@ -16,29 +18,25 @@ module asa_row(row=3, column = 0) {
   // this is _incredibly_ intensive
   //$rounded_key = true;
 
-  $top_tilt_y = side_tilt(column);
-  extra_height =  $double_sculpted ? extra_side_tilt_height(column) : 0;
-
-  if (row <= 1){
-    $total_depth = 10.65 + extra_height;
+  if (row == 1){
+    $bottom_key_width = 17.95;
+    $width_difference = 4.95;
+    $total_depth = 10.65;
     $top_tilt = 7;
     children();
   } else if (row == 2) {
-    $total_depth = 9.65 + extra_height;
+    $bottom_key_width = 18.17;
+    $width_difference = 5.17;
+    $total_depth = 9.65;
     $top_tilt = 3.25;
     children();
-  } else if (row == 3) {
-    $total_depth = 10.35 + extra_height;
-    $top_tilt = 1.5;
-    children();
-  } else if (row == 4 || row == 5){
-    $total_depth = 11.9 + extra_height;
+  } else if (row == 4){
+    $bottom_key_width = 18.02;
+    $width_difference = 5.02;
+    $total_depth = 11.9;
     $top_tilt = 0.43;
     children();
   } else {
-    // Same as row == 3
-    $total_depth = 10.35 + extra_height;
-    $top_tilt = 1.5;
     children();
   }
 }


### PR DESCRIPTION
## Background

I notices this profile was not available in the codebase.
According to [this guide](https://epomaker.com/blogs/guides/keycaps-profiles-overview-what-are-they-and-how-to-choose), "The ASA profile mixes the height of the OEM profile and maintains the spherical shape of keycaps. It's a customized profile provided by the AKKO."

Some additional information on the internet revealed a few more details on the profile:

![9a05f0c6-fab2-4d71-858f-4e6ad1d50be8 __CR0,0,970,300_PT0_SX970_V1___](https://user-images.githubusercontent.com/3267001/131343849-095414f5-44d7-4cc1-8cf0-1ea398d9a1e5.jpg)
![bc4647c9-25d6-4642-ac4c-785fb0320f38 __CR0,0,970,600_PT0_SX970_V1___](https://user-images.githubusercontent.com/3267001/131343854-988ec79d-96c8-4f97-b722-d95f5d14fde5.jpg)
I have my own set of ASA keys and, using callipers, I found the height of the top is 12mm.

Knowing all that I was able to calculate the tilts for the tops for each row.

I measured the bottom of 10 keys for each row with calipers (Width and Height) and then averaged the results.

Base Height | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | Average
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
R1 | 18.07 | 18.06 | 18.07 | 18.07 | 18.07 | 18.06 | 18.07 | 18.07 | 18.07 | 18.07 | 18.068
R2 | 18.06 | 18.05 | 18.06 | 18.06 | 18.05 | 18.05 | 18.04 | 18.07 | 18.05 | 18.06 | 18.055
R3 | 18.06 | 18.07 | 18.07 | 18.09 | 18.07 | 18.06 | 18.07 | 18.07 | 18.08 | 18.07 | 18.071
R4 | 18.05 | 18.08 | 18.06 | 18.05 | 18.06 | 18.07 | 18.07 | 18.04 | 18.06 | 18.05 | 18.059
  |   |   |   |   |   |   |   |   |   | Overall average | 18.063


Base Width | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | Average
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
R1 | 17.95 | 17.96 | 17.94 | 17.94 | 17.95 | 17.96 | 17.96 | 17.96 | 17.96 | 17.96 | 17.9540
R2 | 18.19 | 18.17 | 18.19 | 18.09 | 18.17 | 18.09 | 18.19 | 18.19 | 18.18 | 18.19 | 18.1650
R3 | 18.05 | 18.07 | 18.05 | 18.05 | 18.06 | 18.04 | 18.05 | 18.06 | 18.04 | 18.05 | 18.0520
R4 | 18.02 | 18.04 | 18.00 | 18.01 | 18.02 | 18.02 | 18.02 | 18.01 | 18.00 | 18.01 | 18.0150
  |   |   |   |   |   |   |   |   |   | Overall average | 18.0465


I think that the heights seem to be mostly consistent across the board.
This I would say it is reasonable to use the overall average value of 18.06 (rounded)

For the widths, the values for each row as not as consistent, so I would use the average values for each row and use the overall average value of 18.05 (again rounded) as a default (for row 5 and beyond)

  | Base Height | Base Width
-- | -- | --
R1 | 18.06 | 17.95
R2 | 18.06 | 18.17
R3 | 18.06 | 18.05
R4 | 18.06 | 18.02
Default | 18.06 | 18.05


The assumption is that everything else about the shape of the keys is the same as the SA profile.

 The below code produces the below output:

```
include <KeyV2/includes.scad>

legends = [
    "R1",
    "R2",
    "R3",
    "R4",
];

for(row=[1:4]) {
  translate_u(0,row)
  asa_row(row=row)
  legend(legends[row-1], [0,0, 6])
  key();
}
```

![preview](https://user-images.githubusercontent.com/3267001/140612627-043f619e-3bfe-4041-aa00-6f3a8386bb1e.png)


## Changes
- Create src/key_profiles/asa.scad to handle config for ASA profile
- Add new profile to src/key_profiles.scad