### PR TITLE
This path does not seem to exists

### DIFF
--- a/src/stems.scad
+++ b/src/stems.scad
@@ -4,7 +4,6 @@ include <stems/box_cherry.scad>
 include <stems/alps.scad>
 include <stems/filled.scad>
 include <stems/cherry_stabilizer.scad>
-include <stems/custom.scad>
 
 
 //whole stem, alps or cherry, trimmed to fit


### PR DESCRIPTION
## Background

While playing around in the master branch, I found that this path was broken.
I raises a warning while in the OpenScad IDE.

## Changes
- Remove broken include in src/stems.scad