### PR TITLE
V2: Fix lexical scoping in sculpted square in V2.x.x

### DIFF
--- a/customizer.scad
+++ b/customizer.scad
@@ -2108,18 +2108,18 @@ function skin_iso_enter_shape(size, delta, progress, thickness_difference) =
 // rounded square shape with additional sculpting functions to better approximate
 
 // When sculpting sides, how much in should the tops come
-$side_sculpting_factor = 4.5;
+side_sculpting_factor = 4.5;
 // When sculpting corners, how much extra radius should be added
-$corner_sculpting_factor = 1;
+corner_sculpting_factor = 1;
 // When doing more side sculpting corners, how much extra radius should be added
-$more_side_sculpting_factor = 0.4;
+more_side_sculpting_factor = 0.4;
 
 
 // side sculpting functions
 // bows the sides out on stuff like SA and DSA keycaps
-function side_sculpting(progress) = (1 - progress) * $side_sculpting_factor;
+function side_sculpting(progress) = (1 - progress) * side_sculpting_factor;
 // makes the rounded corners of the keycap grow larger as they move upwards
-function corner_sculpting(progress) = pow(progress, 2) * $corner_sculpting_factor;
+function corner_sculpting(progress) = pow(progress, 2) * corner_sculpting_factor;
 
 module sculpted_square_shape(size, delta, progress) {
   width = size[0];
@@ -2144,7 +2144,7 @@ module sculpted_square_shape(size, delta, progress) {
 
   offset(r = extra_corner_radius_this_slice, $fa=360/$shape_facets) {
     offset(r = -extra_corner_radius_this_slice) {
-      side_rounded_square(square_size, r = $more_side_sculpting_factor * progress);
+      side_rounded_square(square_size, r = more_side_sculpting_factor * progress);
     }
   }
 }
@@ -2199,7 +2199,7 @@ function skin_sculpted_square_shape(size, delta, progress, thickness_difference)
       width - extra_width_this_slice - thickness_difference,
       height - extra_height_this_slice - thickness_difference
     ]
-  ) new_side_rounded_square(square_size, $more_side_sculpting_factor * progress, extra_corner_radius_this_slice);
+  ) new_side_rounded_square(square_size, more_side_sculpting_factor * progress, extra_corner_radius_this_slice);
 
 
 module side_rounded_square(size, r) {

--- a/src/shapes/sculpted_square.scad
+++ b/src/shapes/sculpted_square.scad
@@ -1,18 +1,18 @@
 // rounded square shape with additional sculpting functions to better approximate
 
 // When sculpting sides, how much in should the tops come
-$side_sculpting_factor = 4.5;
+side_sculpting_factor = 4.5;
 // When sculpting corners, how much extra radius should be added
-$corner_sculpting_factor = 1;
+corner_sculpting_factor = 1;
 // When doing more side sculpting corners, how much extra radius should be added
-$more_side_sculpting_factor = 0.4;
+more_side_sculpting_factor = 0.4;
 
 
 // side sculpting functions
 // bows the sides out on stuff like SA and DSA keycaps
-function side_sculpting(progress) = (1 - progress) * $side_sculpting_factor;
+function side_sculpting(progress) = (1 - progress) * side_sculpting_factor;
 // makes the rounded corners of the keycap grow larger as they move upwards
-function corner_sculpting(progress) = pow(progress, 2) * $corner_sculpting_factor;
+function corner_sculpting(progress) = pow(progress, 2) * corner_sculpting_factor;
 
 module sculpted_square_shape(size, delta, progress) {
   width = size[0];
@@ -37,7 +37,7 @@ module sculpted_square_shape(size, delta, progress) {
 
   offset(r = extra_corner_radius_this_slice, $fa=360/$shape_facets) {
     offset(r = -extra_corner_radius_this_slice) {
-      side_rounded_square(square_size, r = $more_side_sculpting_factor * progress);
+      side_rounded_square(square_size, r = more_side_sculpting_factor * progress);
     }
   }
 }
@@ -92,7 +92,7 @@ function skin_sculpted_square_shape(size, delta, progress, thickness_difference)
       width - extra_width_this_slice - thickness_difference,
       height - extra_height_this_slice - thickness_difference
     ]
-  ) new_side_rounded_square(square_size, $more_side_sculpting_factor * progress, extra_corner_radius_this_slice);
+  ) new_side_rounded_square(square_size, more_side_sculpting_factor * progress, extra_corner_radius_this_slice);
 
 
 module side_rounded_square(size, r) {


### PR DESCRIPTION
swear I already did this... oh well