### PR TITLE
Force ISO enter to render as it does not show in preview

### DIFF
--- a/customizer.scad
+++ b/customizer.scad
@@ -928,9 +928,10 @@ module iso_enter() {
   // this equals (unit_length(1.5) - unit_length(1.25)) / 2
   /* $dish_overdraw_width = 2.38125; */
 
-
-  stabilized(vertical=true) {
-    children();
+  render() {
+    stabilized(vertical=true) {
+      children();
+    }
   }
 }
 // kind of a catch-all at this point for any directive that doesn't fit in the other files

--- a/src/key_types.scad
+++ b/src/key_types.scad
@@ -55,8 +55,9 @@ module iso_enter() {
   // this equals (unit_length(1.5) - unit_length(1.25)) / 2
   /* $dish_overdraw_width = 2.38125; */
 
-
-  stabilized(vertical=true) {
-    children();
+  render() {
+    stabilized(vertical=true) {
+      children();
+    }
   }
 }


### PR DESCRIPTION
The good news is, ISO enter finally works. Many thanks to 
Irev-Dev with `round-anything`.

The bad(ish) news is that it just plain doesn't show up in preview mode. So, this PR forces any iso_enter key to render, so people aren't confused.

Rendering can be an expensive operation in this library so I was reticent to do this initially, but your average ISO keyset has 1 enter key, so I think it's the better choice.