### PR TITLE
Add Key Bump for Layouts

### DIFF
--- a/src/key.scad
+++ b/src/key.scad
@@ -177,6 +177,14 @@ module inner_shape(extra_wall_thickness = 0, extra_keytop_thickness = 0) {
 // additive objects at the top of the key
 module additive_features(inset) {
   top_of_key() {
+    // Allow for key bump in layout
+    if ($layout_key_bump) {
+      for (layout_bump_key = $layout_bump_keys){
+        if (str($legends[0][0]) == layout_bump_key){
+          keybump($key_bump_depth, $key_bump_edge);
+        }
+      }
+    }
     if($key_bump) keybump($key_bump_depth, $key_bump_edge);
     if(!inset && $children > 0) color($secondary_color) children();
   }

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -136,6 +136,8 @@ $minkowski_radius = .33;
 
 //insert locating bump
 $key_bump = false;
+$layout_key_bump = false;
+$layout_bump_keys = ["F","f","J","j"];
 //height of the location bump from the top surface of the key
 $key_bump_depth = 0.5;
 //distance to move the bump from the front edge of the key


### PR DESCRIPTION
Allows for key bumps to be added to layout designs through the bool $layout_key_bump being set to true and the the keys which should receive the key bump being in the list $layout_bump_keys = ["F","f","J","j"];