### PR TITLE
V2: Make tine support work for offset stems, remove $extra_long_stem_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These modifier functions may not cover every use case; in that case, you may hav
 
 new to the library and still in a beta state, layouts allows you to generate an entire layout for a keyboard!
 
-It is recommended to use tined stem support and set `$extra_long_stem_support = true` if you plan on printing these keycaps.
+It is recommended to print layouts with a brim that extends to the next key.
 
 ```
 60_percent_default("dcs") key();

--- a/customizer.scad
+++ b/customizer.scad
@@ -94,10 +94,6 @@ $stem_inset = 0;
 // How many degrees to rotate the stems. useful for sideways keycaps, maybe
 $stem_rotation = 0;
 
-// enable to have stem support extend past the keycap bottom, to (hopefully) the next
-// keycap. only works on tines right now
-$extra_long_stem_support = false;
-
 /* [Shape] */
 
 // Key shape type, determines the shape of the key. default is 'rounded square'
@@ -4330,17 +4326,20 @@ module cherry_stem(depth, slop, throw) {
   }
 }
 
+/* NOTE: every reference to total_key_width and total_key_height
+ * is multiplied by two in order to account for offset stems
+ */ 
 module centered_tines(stem_support_height) {
   if ($key_length < 2) {
     translate([0,0,$stem_support_height / 2]) {
-      cube([total_key_width(), 0.5, $stem_support_height], center = true);
+      cube([total_key_width()*2, 0.5, $stem_support_height], center = true);
     }
   }
 
   translate([0,0,$stem_support_height / 2]) {
     cube([
       1,
-      total_key_height(),
+      total_key_height()*2,
       $stem_support_height
     ],
     center = true);
@@ -4348,16 +4347,13 @@ module centered_tines(stem_support_height) {
 }
 
 module tines_support(stem_type, stem_support_height, slop) {
-  extra_height = $extra_long_stem_support ? ($unit - total_key_height()) + 0.1 : -$wall_thickness/4; // fudge
-  extra_width = $extra_long_stem_support ? ($unit - total_key_width()) + 0.1 : -$wall_thickness/4;
-
   if (stem_type == "cherry" || stem_type == "costar_stabilizer") {
     difference () {
       union() {
         if ($key_length < 2) {
           translate([0,0,$stem_support_height / 2]) {
             cube([
-              total_key_width() + extra_width*2,
+              total_key_width()*2,
               0.5,
               $stem_support_height
             ], center = true);
@@ -4369,7 +4365,7 @@ module tines_support(stem_type, stem_support_height, slop) {
           translate([x,0,$stem_support_height / 2]) {
             cube([
               0.5,
-              total_key_height() + extra_height*2, // this is to extend past
+              total_key_height()*2, // this is to extend past
               $stem_support_height
             ], center = true);
           }
@@ -4384,7 +4380,7 @@ module tines_support(stem_type, stem_support_height, slop) {
         translate([x,0,$stem_support_height / 2]) {
           cube([
             1,
-            total_key_height($wall_thickness),
+            total_key_height()*2,
             $stem_support_height
           ], center = true);
         }
@@ -4407,9 +4403,9 @@ module tines_support(stem_type, stem_support_height, slop) {
   } else if (stem_type == "alps"){
     centered_tines(stem_support_height);
   } else if (stem_type == "choc"){
-    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness)+$wall_thickness/4, 0.42, $stem_support_height], center = true);
-    /* translate([-5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
-    /* translate([5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
+    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width(), 0.42, $stem_support_height], center = true);
+    /* translate([-5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height(), $stem_support_height], center = true); */
+    /* translate([5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height(), $stem_support_height], center = true); */
   }
 }
 
@@ -6403,10 +6399,6 @@ $rounded_cherry_stem_d = 5.5;
 $stem_inset = 0;
 // How many degrees to rotate the stems. useful for sideways keycaps, maybe
 $stem_rotation = 0;
-
-// enable to have stem support extend past the keycap bottom, to (hopefully) the next
-// keycap. only works on tines right now
-$extra_long_stem_support = false;
 
 /* [Shape] */
 

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -79,10 +79,6 @@ $stem_inset = 0;
 // How many degrees to rotate the stems. useful for sideways keycaps, maybe
 $stem_rotation = 0;
 
-// enable to have stem support extend past the keycap bottom, to (hopefully) the next
-// keycap. only works on tines right now
-$extra_long_stem_support = false;
-
 /* [Shape] */
 
 // Key shape type, determines the shape of the key. default is 'rounded square'

--- a/src/stem_supports/tines.scad
+++ b/src/stem_supports/tines.scad
@@ -1,17 +1,20 @@
 include <../functions.scad>
 include <../stems/cherry.scad>
 
+/* NOTE: every reference to total_key_width and total_key_height
+ * is multiplied by two in order to account for offset stems
+ */ 
 module centered_tines(stem_support_height) {
   if ($key_length < 2) {
     translate([0,0,$stem_support_height / 2]) {
-      cube([total_key_width(), 0.5, $stem_support_height], center = true);
+      cube([total_key_width()*2, 0.5, $stem_support_height], center = true);
     }
   }
 
   translate([0,0,$stem_support_height / 2]) {
     cube([
       1,
-      total_key_height(),
+      total_key_height()*2,
       $stem_support_height
     ],
     center = true);
@@ -19,16 +22,13 @@ module centered_tines(stem_support_height) {
 }
 
 module tines_support(stem_type, stem_support_height, slop) {
-  extra_height = $extra_long_stem_support ? ($unit - total_key_height()) + 0.1 : -$wall_thickness/4; // fudge
-  extra_width = $extra_long_stem_support ? ($unit - total_key_width()) + 0.1 : -$wall_thickness/4;
-
   if (stem_type == "cherry" || stem_type == "costar_stabilizer") {
     difference () {
       union() {
         if ($key_length < 2) {
           translate([0,0,$stem_support_height / 2]) {
             cube([
-              total_key_width() + extra_width*2,
+              total_key_width()*2,
               0.5,
               $stem_support_height
             ], center = true);
@@ -40,7 +40,7 @@ module tines_support(stem_type, stem_support_height, slop) {
           translate([x,0,$stem_support_height / 2]) {
             cube([
               0.5,
-              total_key_height() + extra_height*2, // this is to extend past
+              total_key_height()*2, // this is to extend past
               $stem_support_height
             ], center = true);
           }
@@ -55,7 +55,7 @@ module tines_support(stem_type, stem_support_height, slop) {
         translate([x,0,$stem_support_height / 2]) {
           cube([
             1,
-            total_key_height($wall_thickness),
+            total_key_height()*2,
             $stem_support_height
           ], center = true);
         }
@@ -78,8 +78,8 @@ module tines_support(stem_type, stem_support_height, slop) {
   } else if (stem_type == "alps"){
     centered_tines(stem_support_height);
   } else if (stem_type == "choc"){
-    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width($wall_thickness)+$wall_thickness/4, 0.42, $stem_support_height], center = true);
-    /* translate([-5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
-    /* translate([5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height($wall_thickness), $stem_support_height], center = true); */
+    if ($key_length < 2) translate([0,0,$stem_support_height / 2]) cube([total_key_width(), 0.42, $stem_support_height], center = true);
+    /* translate([-5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height(), $stem_support_height], center = true); */
+    /* translate([5.7/2,0,$stem_support_height / 2]) cube([0.5, total_key_height(), $stem_support_height], center = true); */
   }
 }


### PR DESCRIPTION
$extra_long_stem_support doesn't work any more with the new key structure. It didn't work particularly well anyways, long gaps would not be supported, and just printing an inter-piece brim would be better.

This also allows us to fix off-center stems with tine support, as we can extend them as far as we want because we know they'll be limited to the inside of the keycap.