### PR TITLE
Hex style

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,11 @@
 TODO:
-  * Make flat stem support default
+  * implement key_shape_at_progress which allows you to query for the exact 2d outline of the keycap at a given height
+    * this makes certain functions easier - building the envelope for instance
+    * requires breaking out shape_slice, and creating a polygon of the skin_shape_slice slices
+  * dishes add / remove height from keycaps, particularly spherical dishes
+    * a bandaid solution would be to allow you to modify where the keytop is along the progression of the keycap
+      * you can't just set a new total_depth because of how width_difference and height_difference work
+    * the true solution would be to rewrite how the dishes work to make them very graduated at the edges
   * implement regular polygon for skin extrusions
   * switch to skin-shaped extrusions by default
   * kailh choc has a non-square key unit; should I get that working for layouts etc? 

--- a/customizer.scad
+++ b/customizer.scad
@@ -445,9 +445,6 @@ module dsa_row(row=3, column = 0) {
   $dish_skew_y = 0;
   $height_slices = 10;
 
-  $dish_type = "3d surface";
-  $surface_function = spherical_surface;
-
   $side_sculpting = function(progress) (1 - progress) * 4.5;
   $corner_sculpting = function(progress) pow(progress, 2);
   

--- a/keys.scad
+++ b/keys.scad
@@ -8,38 +8,13 @@
 include <./includes.scad>
 
 
-// $rounded_key = true;
 // example key
-// typewriter_row(5) legend("⇪", size=9) resin() key();
+dcs_row(5) legend("⇪", size=9) key();
 
-// // example row
-// for(y = [0:1:3]) {
-//  for (x = [0:1:4]) {
-//     translate_u(x + y % 2 * 0.5,y) hex_row(x) key();
-//   }
-// }
-
-// $double_sculpted = true;
-// row_length = len(preonic_mit_layout[0]);
-// simple_layout(preonic_mit_layout) {
-//   $keycap_rotation = 90;
-//   // $stem_type = "choc";
-//   adjusted_column = [-1, -1/2, 0, 1/2, 0, -1/2, -1/2, 0, 1/2, 0, -1/2, -1];
-//   column_value = double_sculpted_column($column, row_length, "2hands");
-//   translate_u(0, adjusted_column[$column]) hex_row($row, column_value) {
-//     key();
-//   }
-// }
-
-// $hull_shape_type = "skin";
-dsa_row(1) key();
-translate_u(1) dsa_row(1) {
-  union() {
-    // $total_depth = 11;
-    $inverted_dish = true;
-    key();
-  }
-}
+// example row
+/* for (x = [0:1:4]) {
+  translate_u(0,-x) dcs_row(x) key();
+} */
 
 // example layout
 /* preonic_default("dcs") key(); */

--- a/keys.scad
+++ b/keys.scad
@@ -8,13 +8,38 @@
 include <./includes.scad>
 
 
+// $rounded_key = true;
 // example key
-dcs_row(5) legend("⇪", size=9) key();
+// typewriter_row(5) legend("⇪", size=9) resin() key();
 
-// example row
-/* for (x = [0:1:4]) {
-  translate_u(0,-x) dcs_row(x) key();
-} */
+// // example row
+// for(y = [0:1:3]) {
+//  for (x = [0:1:4]) {
+//     translate_u(x + y % 2 * 0.5,y) hex_row(x) key();
+//   }
+// }
+
+// $double_sculpted = true;
+// row_length = len(preonic_mit_layout[0]);
+// simple_layout(preonic_mit_layout) {
+//   $keycap_rotation = 90;
+//   // $stem_type = "choc";
+//   adjusted_column = [-1, -1/2, 0, 1/2, 0, -1/2, -1/2, 0, 1/2, 0, -1/2, -1];
+//   column_value = double_sculpted_column($column, row_length, "2hands");
+//   translate_u(0, adjusted_column[$column]) hex_row($row, column_value) {
+//     key();
+//   }
+// }
+
+// $hull_shape_type = "skin";
+dsa_row(1) key();
+translate_u(1) dsa_row(1) {
+  union() {
+    // $total_depth = 11;
+    $inverted_dish = true;
+    key();
+  }
+}
 
 // example layout
 /* preonic_default("dcs") key(); */

--- a/src/dishes/3d_surface.scad
+++ b/src/dishes/3d_surface.scad
@@ -6,7 +6,7 @@ module 3d_surface_dish(width, height, depth, inverted) {
   // it doesn't have to be dead reckoning for anything but sculpted sides
   // we know the angle of the sides from the width difference, height difference,
   // skew and tilt of the top. it's a pain to calculate though
-  scale_factor = 1.11;
+  scale_factor = 1.05;
   // the edges on this behave differently than with the previous dish implementations
   scale([width*scale_factor/$3d_surface_size/2,height*scale_factor/$3d_surface_size/2,depth])
     rotate([inverted ? 0:180,0,180])

--- a/src/dishes/spherical.scad
+++ b/src/dishes/spherical.scad
@@ -1,4 +1,8 @@
 module spherical_dish(width, height, depth, inverted){
+  // these variables take into account corner_radius and corner_sculpting, resulting in a more correct dish
+  // they don't fix the core issue though (dishes adding / subtracting height on the edges of the keycap), so I've disabled them
+  // new_width = $key_shape_type == "sculpted_square" ? width - distance_between_circumscribed_and_inscribed($corner_radius + $corner_sculpting(1)) : width;
+  // new_height = $key_shape_type == "sculpted_square" ? height - distance_between_circumscribed_and_inscribed($corner_radius + $corner_sculpting(1)) : height;
 
   //same thing as the cylindrical dish here, but we need the corners to just touch - so we have to find the hypotenuse of the top
   chord = pow((pow(width,2) + pow(height, 2)),0.5); //getting diagonal of the top

--- a/src/functions.scad
+++ b/src/functions.scad
@@ -4,7 +4,7 @@ include <constants.scad>
 // functions need to be explicitly included, unlike special variables, which
 // just need to have been set before they are used. hence this file
 
-function stem_height() = $total_depth - $dish_depth - $stem_inset;
+function stem_height() = $total_depth - ($dish_depth * ($inverted_dish ? -1 : 1))  - $stem_inset;
 
 // cherry stem dimensions
 function outer_cherry_stem(slop) = [7.2 - slop * 2, 5.5 - slop * 2];
@@ -22,6 +22,10 @@ function cherry_cross(slop, extra_vertical = 0) = [
   // vertical tine
   [1.15 + slop / 3, 4.23 + extra_vertical + slop / 3 + SMALLEST_POSSIBLE],
 ];
+
+// TODO add side_sculpting
+function key_width_at_progress(progress = 0) = $bottom_key_width + ($unit * ($key_length - 1)) - $width_difference;
+function key_height_at_progress(progress = 0) = $bottom_key_height + ($unit * ($key_length - 1)) - $height_difference + $side_sculpting(progress);
 
 // actual mm key width and height
 function total_key_width(delta = 0) = $bottom_key_width + $unit * ($key_length - 1) - delta;
@@ -47,3 +51,7 @@ function extra_keytop_length_for_flat_sides() = ($width_difference * vertical_in
 function add_rounding(p, radius)=[for(i=[0:len(p)-1])[p[i].x,p[i].y, radius]];
 // computes millimeter length from unit length
 function unit_length(length) = $unit * (length - 1) + 18.16;
+
+// if you have a radius of an inscribed circle, this function gives you the extra length for the radius of the circumscribed circle
+// and vice versa. used to find the edge of a rounded_square
+function distance_between_circumscribed_and_inscribed(radius) = (pow(2, 0.5) - 1) * radius;

--- a/src/key_profiles.scad
+++ b/src/key_profiles.scad
@@ -15,6 +15,7 @@ include <key_profiles/cherry.scad>
 include <key_profiles/dss.scad>
 include <key_profiles/asa.scad>
 include <key_profiles/typewriter.scad>
+include <key_profiles/hex.scad>
 
 // man, wouldn't it be so cool if functions were first order
 module key_profile(key_profile_type, row, column=0) {
@@ -38,6 +39,8 @@ module key_profile(key_profile_type, row, column=0) {
     grid_row(row, column) children();
   } else if (key_profile_type == "typewriter") {
     typewriter_row(row, column) children();
+  } else if (key_profile_type == "hex") { // reddit.com/r/MechanicalKeyboards/comments/kza7ji
+    hex_row(row, column) children();
   } else if (key_profile_type == "hexagon") {
     hexagonal_row(row, column) children();
   } else if (key_profile_type == "octagon") {

--- a/src/key_profiles/asa.scad
+++ b/src/key_profiles/asa.scad
@@ -13,7 +13,12 @@ module asa_row(row=3, column = 0) {
   $top_skew = 1.75;
   $stem_inset = 1.2;
   $height_slices = 10;
+
   $corner_radius = 1;
+  $more_side_sculpting_factor = 0.4;
+
+  $side_sculpting = function(progress) (1 - progress) * 4.5;
+  $corner_sculpting = function(progress) pow(progress, 2);
 
   // this is _incredibly_ intensive
   //$rounded_key = true;

--- a/src/key_profiles/dsa.scad
+++ b/src/key_profiles/dsa.scad
@@ -11,8 +11,15 @@ module dsa_row(row=3, column = 0) {
   $dish_skew_x = 0;
   $dish_skew_y = 0;
   $height_slices = 10;
-  $enable_side_sculpting = true;
+
+  $dish_type = "3d surface";
+  $surface_function = spherical_surface;
+
+  $side_sculpting = function(progress) (1 - progress) * 4.5;
+  $corner_sculpting = function(progress) pow(progress, 2);
+  
   $corner_radius = 1;
+  $more_side_sculpting_factor = 0.4;
 
   $top_tilt_y = side_tilt(column);
   extra_height = $double_sculpted ? extra_side_tilt_height(column) : 0;

--- a/src/key_profiles/dsa.scad
+++ b/src/key_profiles/dsa.scad
@@ -12,9 +12,6 @@ module dsa_row(row=3, column = 0) {
   $dish_skew_y = 0;
   $height_slices = 10;
 
-  $dish_type = "3d surface";
-  $surface_function = spherical_surface;
-
   $side_sculpting = function(progress) (1 - progress) * 4.5;
   $corner_sculpting = function(progress) pow(progress, 2);
   

--- a/src/key_profiles/dss.scad
+++ b/src/key_profiles/dss.scad
@@ -10,10 +10,13 @@ module dss_row(n=3, column=0) {
   $dish_skew_y = 0;
   $top_skew = 0;
   $height_slices = 10;
-  $enable_side_sculpting = true;
   // might wanna change this if you don't minkowski
   // do you even minkowski bro
   $corner_radius = 1;
+  $more_side_sculpting_factor = 0.4;
+
+  $side_sculpting = function(progress) (1 - progress) * 4.5;
+  $corner_sculpting = function(progress) pow(progress, 2);
 
   // this is _incredibly_ intensive
   /* $rounded_key = true; */

--- a/src/key_profiles/hex.scad
+++ b/src/key_profiles/hex.scad
@@ -3,22 +3,27 @@ include <../constants.scad>
 // This is to make tiling them easier, like in the case of hexagonal keycaps etc
 
 // this function doesn't set the key shape, so you can't use it directly without some fiddling
-module typewriter_row(n=3, column=0) {
+module hex_row(n=3, column=0) {
   $bottom_key_width = $unit - 0.5;
   $bottom_key_height = $unit - 0.5;
+  
   $width_difference = 0;
   $height_difference = 0;
+  
   $dish_type = "spherical";
-  $key_shape_type = "circular";
-  $inverted_dish = true;
-  $stem_inset = -4.5;
-  $stem_throw = 5;
-  $dish_depth = 4;
-  $dish_skew_x = 0;
-  $dish_skew_y = 0;
+  $key_shape_type = "hexagon";
+
+  $stem_inset = -2.5;
+  $stem_throw = 3;
+
+  // $dish_depth = 1;
+
   $top_skew = 0;
   $height_slices = 1;
   $stem_support_type = "disable";
+  
+  $dish_overdraw_width = -8.25;
+  $dish_overdraw_height = -8.25;
 //   $corner_radius = 1;
 
   // this is _incredibly_ intensive
@@ -27,7 +32,7 @@ module typewriter_row(n=3, column=0) {
   $top_tilt_y = side_tilt(column);
   extra_height = $double_sculpted ? extra_side_tilt_height(column) : 0;
 
-  base_depth = 3.5;
+  base_depth = 4;
   if (n <= 1){
     $total_depth = base_depth + 2.5 + extra_height;
     $top_tilt = -13;

--- a/src/key_profiles/hipro.scad
+++ b/src/key_profiles/hipro.scad
@@ -12,7 +12,12 @@ module hipro_row(row=3, column=0) {
   $dish_skew_y = 0;
   $top_skew = 0;
   $height_slices = 10;
+
   $corner_radius = 1;
+  $more_side_sculpting_factor = 0.4;
+
+  $side_sculpting = function(progress) (1 - progress) * 4.5;
+  $corner_sculpting = function(progress) pow(progress, 2);
 
   $top_tilt_y = side_tilt(column);
   extra_height =  $double_sculpted ? extra_side_tilt_height(column) : 0;

--- a/src/key_profiles/mt3.scad
+++ b/src/key_profiles/mt3.scad
@@ -14,10 +14,12 @@ module mt3_row(row=3, column=0, deep_dish=false) {
   $top_skew = 0;
   $height_slices = 10;
 
-  $corner_sculpting_factor = 2;
   $corner_radius = 0.0125;
-
   $more_side_sculpting_factor = 0.75;
+
+  $side_sculpting = function(progress) (1 - progress) * 4.5;
+  $corner_sculpting = function(progress) pow(progress, 2) * 2;
+
 
   $top_tilt_y = side_tilt(column);
   extra_height =  $double_sculpted ? extra_side_tilt_height(column) : 0;

--- a/src/key_profiles/sa.scad
+++ b/src/key_profiles/sa.scad
@@ -10,7 +10,12 @@ module sa_row(n=3, column=0) {
   $dish_skew_y = 0;
   $top_skew = 0;
   $height_slices = 10;
+
   $corner_radius = 1;
+  $more_side_sculpting_factor = 0.4;
+
+  $side_sculpting = function(progress) (1 - progress) * 4.5;
+  $corner_sculpting = function(progress) pow(progress, 2);
 
   // this is _incredibly_ intensive
   /* $rounded_key = true; */

--- a/src/libraries/3d_surface.scad
+++ b/src/libraries/3d_surface.scad
@@ -3,7 +3,7 @@
 include <../functions.scad>
 
 module 3d_surface(size=$3d_surface_size, step=$3d_surface_step, bottom=-SMALLEST_POSSIBLE){
-  function p(x, y) = [ x, y, max(0,$surface_function(x, y)) ];
+  function p(x, y) = [ x, y, max(0,$surface_function(x, y) * $corner_smoothing_surface_function(x,y)) ];
   function p0(x, y) = [ x, y, bottom ];
   function rev(b, v) = b ? v : [ v[3], v[2], v[1], v[0] ];
   function face(x, y) = [ p(x, y + step), p(x + step, y + step), p(x + step, y), p(x + step, y), p(x, y), p(x, y + step) ];
@@ -41,7 +41,7 @@ module polar_3d_surface(size, step, bottom=-SMALLEST_POSSIBLE){
   function p(x, y) = [
     $surface_distribution_function(to_polar(x, size), size),
     $surface_distribution_function(to_polar(y, size), size),
-    max(0,$surface_function($surface_distribution_function(to_polar(x, size), size), $surface_distribution_function(to_polar(y, size), size)))
+    max(0,$surface_function($surface_distribution_function(to_polar(x, size), size), $surface_distribution_function(to_polar(y, size), size)) * $corner_smoothing_surface_function($surface_distribution_function(to_polar(x, size), size), $surface_distribution_function(to_polar(y, size), size)))
   ];
   function p0(x, y) = [ x, y, bottom ];
   function rev(b, v) = b ? v : [ v[3], v[2], v[1], v[0] ];

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -76,8 +76,10 @@ $rounded_cherry_stem_d = 5.5;
 // Inset stem requires support but is more accurate in some profiles
 // can be negative to make outset stems!
 $stem_inset = 0;
-// How many degrees to rotate the stems. useful for sideways keycaps, maybe
+// How many degrees to rotate the stems. useful for sideways keycaps
 $stem_rotation = 0;
+// How many degrees to rotate the keycap, but _not_ inside features (the stem). 
+$keycap_rotation = 0;
 
 /* [Shape] */
 
@@ -195,29 +197,29 @@ $shape_facets =30;
 // "flat" / "dished" / "disable"
 $inner_shape_type = "flat";
 
-// When sculpting sides using sculpted_square, how much in should the tops come
-$side_sculpting_factor = 4.5;
-// When sculpting corners, how much extra radius should be added
-$corner_sculpting_factor = 1;
-// When doing more side sculpting corners, how much extra radius should be added
-$more_side_sculpting_factor = 0.4;
+// default side_sculpting function, linear
+$side_sculpting = function(progress) 0;
+$corner_sculpting = function(progress) 0;
+
+// you probably shouldn't touch this, it's internal to sculpted_square
+// modify side sculpting with the $side_sculpting function in the key profile files
+$more_side_sculpting_factor = 0;
 
 // 3d surface functions (still in beta)
 
 // 3d surface settings
 // unused for now
-$3d_surface_size = 20;
-// resolution in each axis. 10 = 10 divisions per x/y = 100 points total. 
-// 5 = 20 divisions per x/y
-$3d_surface_step = 1;
+$3d_surface_size = 1;
+// 3d surface point resolution. $3d_surface_size / $3d_surface_step = steps per x / y
+$3d_surface_step = 1/20;
 
 // monotonically increasing function that distributes the points of the surface mesh
 // only for polar_3d_surface right now
 // if it's linear it's a grid. sin(dim) * size concentrates detail around the edges
 sinusoidal_surface_distribution = function(dim,size) sin(dim) * size;
-linear_surface_distribution = function(dim,size) sin(dim) * size;
+linear_surface_distribution = function(dim,size) dim;
 
-$surface_distribution_function = linear_surface_distribution;
+$surface_distribution_function = sinusoidal_surface_distribution;
 
 // the function that actually determines what the surface is.
 // feel free to override, the last one wins
@@ -235,6 +237,10 @@ random_surface = function(x,y) sin(rands(0,90,1,x+y)[0]);
 bumps_surface = function(x,y) sin(20*x)*cos(20*y)/3+1;
 
 $surface_function = bumps_surface; // bumps_surface;
+
+// can be used to smooth the corners of the 3d surface function, to make the dishes add / subtract less height. can really do anything it's just multiplying, but that's what I use it for
+$corner_smoothing_surface_function = function(x,y) 1;
+// $corner_smoothing_surface_function = function(x,y) (1 - pow(abs(x), 5)/$3d_surface_size) * (1 - pow(abs(y),5)/$3d_surface_size);
 
 // ripples
 /* 

--- a/src/shapes/sculpted_square.scad
+++ b/src/shapes/sculpted_square.scad
@@ -13,9 +13,9 @@ module sculpted_square_shape(size, delta, progress) {
   width_difference = delta[0];
   height_difference = delta[1];
   // makes the sides bow
-  extra_side_size =  side_sculpting(progress);
+  extra_side_size =  $side_sculpting(progress);
   // makes the rounded corners of the keycap grow larger as they move upwards
-  extra_corner_size = corner_sculpting(progress);
+  extra_corner_size = $corner_sculpting(progress);
 
   // computed values for this slice
   extra_width_this_slice = (width_difference - extra_side_size) * progress;
@@ -71,9 +71,9 @@ function skin_sculpted_square_shape(size, delta, progress, thickness_difference)
     width_difference = delta[0],
     height_difference = delta[1],
     // makes the sides bow
-    extra_side_size =  side_sculpting(progress),
+    extra_side_size =  $side_sculpting(progress),
     // makes the rounded corners of the keycap grow larger as they move upwards
-    extra_corner_size = corner_sculpting(progress),
+    extra_corner_size = $corner_sculpting(progress),
 
     // computed values for this slice
     extra_width_this_slice = (width_difference - extra_side_size) * progress,


### PR DESCRIPTION
Hello again!

This PR is mostly concerned with implementing these cool [Hex-style keycaps](reddit.com/r/MechanicalKeyboards/comments/kza7ji). The spacing on these isn't a 19.05mm square, so while they fit on a regular keyboard, they won't perfectly tessellate unless you make a custom pcb.

In addition, I solved negative inset stems poking out of the tops of keycaps. 

I also pulled the side and corner sculpting functions out into settings.scad. This allows you to modify the functions on the fly - this is used internally to assign different sculpting patterns to different key profiles.

Changes to key.scad and the side / corner sculpting could possibly be breaking changes, so this will be a major version bump. Kind of a dick move to disappear for months and then push major changes :/