### PR TITLE
Font can be explicitly set on a legend

### DIFF
--- a/src/features/legends.scad
+++ b/src/features/legends.scad
@@ -1,9 +1,9 @@
-module keytext(text, position, font_size, depth) {
+module keytext(text, position, font_size, font_face, depth) {
   woffset = (top_total_key_width()/3.5) * position[0];
   hoffset = (top_total_key_height()/3.5) * -position[1];
   translate([woffset, hoffset, -depth]){
     color($tertiary_color) linear_extrude(height=$dish_depth + depth){
-      text(text=text, font=$font, size=font_size, halign="center", valign="center");
+      text(text=text, font=font_face, size=font_size, halign="center", valign="center");
     }
   }
 }
@@ -12,14 +12,14 @@ module legends(depth=0) {
   if (len($front_legends) > 0) {
     front_of_key() {
       for (i=[0:len($front_legends)-1]) {
-        rotate([90,0,0]) keytext($front_legends[i][0], $front_legends[i][1], $front_legends[i][2], depth);
+        rotate([90,0,0]) keytext($front_legends[i][0], $front_legends[i][1], $front_legends[i][2], $front_legends[i][3], depth);
   	  }
     }
   }
   if (len($legends) > 0) {
     top_of_key() {
       for (i=[0:len($legends)-1]) {
-        keytext($legends[i][0], $legends[i][1], $legends[i][2], depth);
+        keytext($legends[i][0], $legends[i][1], $legends[i][2], $legends[i][3], depth);
       }
     }
   }

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -158,15 +158,17 @@ module flat_support() {
   children();
 }
 
-module legend(text, position=[0,0], size=undef) {
+module legend(text, position=[0,0], size=undef, font=undef) {
     font_size = size == undef ? $font_size : size;
-    $legends = [for(L=[$legends, [[text, position, font_size]]], a=L) a];
+    font_face = font == undef ? $font : font;
+    $legends = [for(L=[$legends, [[text, position, font_size, font_face]]], a=L) a];
     children();
 }
 
-module front_legend(text, position=[0,0], size=undef) {
+module front_legend(text, position=[0,0], size=undef, font=undef) {
     font_size = size == undef ? $font_size : size;
-    $front_legends = [for(L=[$front_legends, [[text, position, font_size]]], a=L) a];
+    font_face = font == undef ? $font : font;
+    $front_legends = [for(L=[$front_legends, [[text, position, font_size, font_face]]], a=L) a];
     children();
 }
 
@@ -206,7 +208,7 @@ module sideways() {
  * then we extend the line created by the slope of the keytop to that line
  * the angle of the latter line off the ground is $top_tilt, and
  * you can create a right triangle with the adjacent edge being $bottom_key_height/2
- * raised up $total_depth. this gets you x, the component of the extended 
+ * raised up $total_depth. this gets you x, the component of the extended
  * keytop slope line, and y, a component of the first perpendicular line.
  * by a very similar triangle you get r and s, where x is the hypotenuse of that
  * right triangle and the right angle is again against the first perpendicular line
@@ -229,7 +231,7 @@ module backside() {
   s = cos(-$top_tilt) * x;
 
   q = atan2(s, (y + b - r));
-  
+
   translate([0,0,cos(q) * total_key_height()/2])
     rotate([-90 - q, 0,0]) children();
 }


### PR DESCRIPTION
... instead of using one font for all legends. Super handy for using a clear text font alongside an icon font.

Supercedes #168 