### PR TITLE
XDA profile

### DIFF
--- a/src/key_profiles.scad
+++ b/src/key_profiles.scad
@@ -16,6 +16,7 @@ include <key_profiles/dss.scad>
 include <key_profiles/asa.scad>
 include <key_profiles/typewriter.scad>
 include <key_profiles/hex.scad>
+include <key_profiles/xda.scad>
 
 // man, wouldn't it be so cool if functions were first order
 module key_profile(key_profile_type, row, column=0) {
@@ -48,7 +49,9 @@ module key_profile(key_profile_type, row, column=0) {
   } else if (key_profile_type == "cherry") {
     cherry_row(row, column) children();
   } else if (key_profile_type == "mt3") {
-    mt3_row(row, column) children();  
+    mt3_row(row, column) children();
+  } else if (key_profile_type == "xda") {
+    xda_row(row, column) children();
   } else if (key_profile_type == "disable") {
     children();
   } else {

--- a/src/key_profiles/xda.scad
+++ b/src/key_profiles/xda.scad
@@ -1,0 +1,29 @@
+use <../functions.scad>
+include <../settings.scad>
+
+module xda_row(row=0, column = 0) {
+  $key_shape_type = "sculpted_square";
+  $bottom_key_width = 18.1;
+  $bottom_key_height = 18.1;
+  $width_difference = 3.7;
+  $height_difference = 3.7;
+  $top_tilt = 0;
+  $top_skew = 0;
+  $dish_type = "spherical";
+  $dish_skew_x = 0;
+  $dish_skew_y = 0;
+  $height_slices = 10;
+  $enable_side_sculpting = true;
+  $corner_radius = 0.6;
+
+  $side_sculpting = function(progress) (1 - progress) * 3.5;
+  $corner_sculpting = function(progress) pow(progress, 2) * 3;
+
+  $top_tilt_y = side_tilt(column);
+  extra_height = $double_sculpted ? extra_side_tilt_height(column) : 0;
+
+  // These together make the height = 9.7 at the corners and 9 at the center
+  $total_depth = 10.3 + extra_height;
+  $dish_depth = 1.3;
+  children();
+}


### PR DESCRIPTION
Amazing project! It's wonderful to work with.

I'm building off the work of @kelvie (#87) to implement the XDA keycap style, since I needed them for a project of mine.
I have [a set XDA keycaps](https://www.amazon.com/gp/product/B0B24KY398) and calipers, so here's all the info:

<img width="629" alt="Measurements" src="https://github.com/rsheldiii/KeyV2/assets/18223213/5a744407-5587-4c33-888c-af8a98aef50c">

The measurements I took. The keycaps are cheaply made and dimensions (especially the width of the keycap's base) varied from part to part. Some of these features (like the rounded corners) were difficult to measure accurately as well, so these are all the best approximations I could make.

<img width="300" alt="Screenshot 2023-08-19 at 11 27 35 PM" src="https://github.com/rsheldiii/KeyV2/assets/18223213/b8febc62-79c8-4dd1-b1fb-50ad7f4fb750">
<img width="300" src="https://github.com/rsheldiii/KeyV2/assets/18223213/e0ab2a58-92a0-4818-9a8c-af49bf60d940" />

The rendered keycap & keycap from which I took measurements.

Since XDA keycaps are all uniform as far as I know I've fixed the tilt and height to constant values regardless of the given row/column in the `xda_row` function. Yet it feels weird disregarding the given `row` and `column` to the function.