### PR TITLE
Add resin-friendly features: avoid suction cups & allow drainage

### DIFF
--- a/src/features.scad
+++ b/src/features.scad
@@ -3,3 +3,4 @@
 include <features/key_bump.scad>
 include <features/clearance_check.scad>
 include <features/legends.scad>
+include <features/resin_holes.scad>

--- a/src/features/resin_holes.scad
+++ b/src/features/resin_holes.scad
@@ -36,9 +36,11 @@ module resin_drain_holes() {
   // XXX these calculations are specific to the flared support type
   loft = $stem_throw;
   height = $total_depth-$stem_throw;
-  dy = $key_height*$unit/2;
-  translate([0,dy,loft+height/4])
-  rotate([105,0,0])
-  cylinder(center=true, d=2, h=8);
+  dx = $key_length*$unit/2;
+  for(r=[90, 270])
+  rotate(r)
+  translate([0,dx,loft+height/4-1])
+  rotate([87,0,0])
+  cylinder(center=true, d=3, h=11);
 }
 

--- a/src/features/resin_holes.scad
+++ b/src/features/resin_holes.scad
@@ -1,0 +1,44 @@
+module resin_suction_holes() {
+  if ($key_shape_type != "sculpted_square"
+      && $key_shape_type != "rounded_square"
+      && $key_shape_type != "flat_sided_square"
+      && $key_shape_type != "square") {
+    echo("Warning: unsupported $key_shape_type for resin_suction_holes. disable resin_suction_holes or pick a new shape");
+  }
+
+  dx = $key_length*$unit/2;
+  dy = $key_height*$unit/2;
+
+  for(theta=[0, 180])
+  rotate(theta)
+  {
+    translate([dx,dy])
+    rotate(-45)
+    rotate([90,0,0])
+    cylinder(center=true, d=2, h=8);
+
+    translate([-dx,dy])
+    rotate(45)
+    rotate([90,0,0])
+    cylinder(center=true, d=2, h=8);
+  }
+
+}
+
+module resin_drain_holes() {
+  if ($key_shape_type != "sculpted_square"
+      && $key_shape_type != "rounded_square"
+      && $key_shape_type != "flat_sided_square"
+      && $key_shape_type != "square") {
+    echo("Warning: unsupported $key_shape_type for resin_drain_holes. disable resin_drain_holes or pick a new shape");
+  }
+
+  // XXX these calculations are specific to the flared support type
+  loft = $stem_throw;
+  height = $total_depth-$stem_throw;
+  dy = $key_height*$unit/2;
+  translate([0,dy,loft+height/4])
+  rotate([105,0,0])
+  cylinder(center=true, d=2, h=8);
+}
+

--- a/src/key.scad
+++ b/src/key.scad
@@ -194,6 +194,15 @@ module subtractive_features(inset) {
   // parts of the keycap that will hit the cherry switch
   // this is a little confusing as it eats the stem too
   /* if ($clearance_check) clearance_check(); */
+
+  // resin-specific subtractive features
+  if($resin_suction_holes) {
+    resin_suction_holes();
+  }
+
+  if($resin_drain_holes) {
+    resin_drain_holes();
+  }
 }
 
 // features inside the key itself (stem, supports, etc)

--- a/src/key_transformations.scad
+++ b/src/key_transformations.scad
@@ -284,5 +284,7 @@ module resin() {
   $stem_slop = 0;
   $stem_inner_slop = 0;
   $stem_support_type = "disable";
+  $resin_suction_holes = true;
+  $resin_drain_holes = true;
   children();
 }

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -236,6 +236,10 @@ bumps_surface = function(x,y) sin(20*x)*cos(20*y)/3+1;
 
 $surface_function = bumps_surface; // bumps_surface;
 
+// Resin subtractive features
+$resin_suction_holes = false;
+$resin_drain_holes = false;
+
 // ripples
 /* 
 // Rosenbrock's banana

--- a/src/settings.scad
+++ b/src/settings.scad
@@ -27,7 +27,7 @@ $double_sculpt_radius = 200;
 $support_type = "flared"; // [flared, bars, flat, disable]
 
 // Supports for the stem, as it often comes off during printing. Reccommended for most machines
-$stem_support_type = "tines"; // [tines, brim, disabled]
+$stem_support_type = "tines"; // [tines, brim, disable]
 
 // make legends outset instead of inset.
 // broken off from artisan support since who wants outset legends?


### PR DESCRIPTION
Design for resin printing differs in important ways from design for FDM printing.

This change aims to improve printability when the base of the keys is against the build plate of a resin printer.

The two printability concerns addressed are:
 * Fully enclosed volumes, called "suction cups". These volumes are undesirable, because the action of pulling up the build plate after exposing a layer creates a vaccum here which can make the print fail.

   By adding breaks at each of the 4 corners of the key, resin can freely flow into the central area and there are no suction cups.

 * Volumes with no holes at the top (model +Z). It's desirable for as much resin as possible to drip free from the print before moving to the cleaning and curing stages.

   By adding a single inclined hole at the back face, resin is allowed to drain out of the central area once the solid layers of the key are reached

These are enabled by the existing `module resin()`, so the typical use remains: `resin() key()`.

I have not yet printed these, and I'm newish to resin printing altogether so please take this with a grain of salt.