### PR TITLE
Fix: A positive inset was also shortening the whole key

### DIFF
--- a/src/key.scad
+++ b/src/key.scad
@@ -66,7 +66,8 @@ module dished(depth_difference = 0, inverted = false) {
     difference(){
       union() {
         // envelope is needed to "fill in" the rest of the keycap. intersections with small objects are much faster than differences with large objects
-        envelope(depth_difference, $stem_inset);
+        // note: enlarge envelope only for negative stems which stick out
+        envelope(depth_difference, $stem_inset < 0 ? $stem_inset : 0);
         if (inverted) top_placement(depth_difference) color($secondary_color) _dish(inverted);
       }
       if (!inverted) top_placement(depth_difference) color($secondary_color) _dish(inverted);


### PR DESCRIPTION
Fix for #175

The bug was introduced in commit e88a398f7a892996269f48c89ae541ece3bb556c, which allowed the stem to stick out of the key (negative inset). However it broke positive insets (recessed stem).